### PR TITLE
RFC / breaking change: Clean up statsd wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ services:
         # more per-service config settings
 ```
 
+# Issue tracking
+
+Please report issues in [the service-runner phabricator
+project](https://phabricator.wikimedia.org/tag/service-runner/).
+
 # See also
 - https://github.com/Unitech/PM2/ - A lot of features. Focus on interactive
     use with commandline tools. Weak on logging (only local log files). Does

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -43,6 +43,12 @@ function makeStatsD(options) {
 
     // Add a static utility method for name normalization
     statsd.normalizeNames = normalizeNames;
+
+    // Also add a small utility to send a delta given a startTime
+    statsd.endTiming = function endTiming(names, startTime, samplingInterval) {
+        return this.timing(names, Date.now() - startTime, samplingInterval);
+    };
+
     return statsd;
 }
 

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -3,23 +3,17 @@ var TXStatsD = require('node-txstatsd');
 var StatsD = require('node-statsd');
 
 var nameCache = {};
-function normalizeNames (names) {
-    if (!Array.isArray(names)) {
-        names = [names];
+function normalizeName (name) {
+    // See https://github.com/etsy/statsd/issues/110
+    // Only [\w_.-] allowed, with '.' being the hierarchy separator.
+    var res = nameCache[name];
+    if (res) {
+        return res;
+    } else {
+        nameCache[name] = name.replace( /[^\/a-zA-Z0-9\.\-]/g, '-' )
+            .replace(/\//g, '_');
+        return nameCache[name];
     }
-
-    return names.map(function(name) {
-        // See https://github.com/etsy/statsd/issues/110
-        // Only [\w_.-] allowed, with '.' being the hierarchy separator.
-        var res = this.nameCache[name];
-        if (res) {
-            return res;
-        } else {
-            nameCache[name] = name.replace( /[^\/a-zA-Z0-9\.\-]/g, '-' )
-                   .replace(/\//g, '_');
-            return this.nameCache[name];
-        }
-    });
 }
 
 // Minimal StatsD wrapper
@@ -41,8 +35,8 @@ function makeStatsD(options) {
         statsd = new StatsD(statsdOptions);
     }
 
-    // Add a static utility method for name normalization
-    statsd.normalizeNames = normalizeNames;
+    // Add a static utility method for stat name normalization
+    statsd.normalizeName = normalizeName;
 
     // Also add a small utility to send a delta given a startTime
     statsd.endTiming = function endTiming(names, startTime, samplingInterval) {

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -16,8 +16,25 @@ function normalizeName (name) {
     }
 }
 
+// A simple console reporter. Useful for development.
+var methods = ['timing','increment','decrement','gauge','unique'];
+function LogStatsD(logger) {
+    var self = this;
+    methods.forEach(function(method) {
+        self[method] = function(name, value, samplingInterval) {
+            logger.log('trace/metrics', {
+                message: [method, name, value].join(':'),
+                method: method,
+                name: name,
+                value: value,
+                samplingInterval: samplingInterval
+            });
+        };
+    });
+}
+
 // Minimal StatsD wrapper
-function makeStatsD(options) {
+function makeStatsD(options, logger) {
     var statsd;
     var statsdOptions = {
         host: options.host,
@@ -31,6 +48,8 @@ function makeStatsD(options) {
     };
     if (options.type === 'txstatsd') {
         statsd = new TXStatsD(statsdOptions);
+    } else if (options.type === 'log') {
+        statsd = new LogStatsD(logger);
     } else {
         statsd = new StatsD(statsdOptions);
     }

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,9 +1,31 @@
 "use strict";
 var TXStatsD = require('node-txstatsd');
+var StatsD = require('node-statsd');
 
-// StatsD wrapper
-function StatsD(options) {
-    this.statsd = new TXStatsD({
+var nameCache = {};
+function normalizeNames (names) {
+    if (!Array.isArray(names)) {
+        names = [names];
+    }
+
+    return names.map(function(name) {
+        // See https://github.com/etsy/statsd/issues/110
+        // Only [\w_.-] allowed, with '.' being the hierarchy separator.
+        var res = this.nameCache[name];
+        if (res) {
+            return res;
+        } else {
+            nameCache[name] = name.replace( /[^\/a-zA-Z0-9\.\-]/g, '-' )
+                   .replace(/\//g, '_');
+            return this.nameCache[name];
+        }
+    });
+}
+
+// Minimal StatsD wrapper
+function makeStatsD(options) {
+    var statsd;
+    var statsdOptions = {
         host: options.host,
         port: options.port,
         prefix: options.name + '.',
@@ -12,46 +34,16 @@ function StatsD(options) {
         globalize : false,
         cacheDns  : true,
         mock      : false
-    });
+    };
+    if (options.type === 'txstatsd') {
+        statsd = new TXStatsD(statsdOptions);
+    } else {
+        statsd = new StatsD(statsdOptions);
+    }
 
-    this.nameCache = {};
+    // Add a static utility method for name normalization
+    statsd.normalizeNames = normalizeNames;
+    return statsd;
 }
 
-StatsD.prototype.makeName = function makeName(name) {
-    // See https://github.com/etsy/statsd/issues/110
-    // Only [\w_.-] allowed, with '.' being the hierarchy separator.
-    var res = this.nameCache[name];
-    if (res) {
-        return res;
-    } else {
-        this.nameCache[name] = name.replace( /[^\/a-zA-Z0-9\.\-]/g, '-' )
-               .replace(/\//g, '_');
-        return this.nameCache[name];
-    }
-};
-
-StatsD.prototype.timing = function timing(name, suffix, delta) {
-    name = this.makeName(name);
-    if (Array.isArray(suffix)) {
-        // Send several timings at once
-        var stats = suffix.map(function(s) {
-            return name + (s ? '.' + s : '');
-        });
-        this.statsd.sendAll(stats, delta, 'ms');
-    } else {
-        suffix = suffix ? '.' + suffix : '';
-        this.statsd.timing(name + suffix, delta);
-    }
-    return delta;
-};
-
-StatsD.prototype.endTiming = function endTiming(name, suffix, start) {
-    return this.timing(name, suffix, Date.now() - start);
-};
-
-StatsD.prototype.count = function count(name, suffix) {
-    suffix = suffix ? '.' + suffix : '';
-    this.statsd.increment(this.makeName(name) + suffix);
-};
-
-module.exports = StatsD;
+module.exports = makeStatsD;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gelf-stream": "^0.2.4",
     "heapdump": "^0.3.3",
     "js-yaml": "~3.2.2",
+    "node-statsd": "^0.1.1",
     "node-txstatsd": "^0.1.5",
     "yargs": "~1.3.0"
   },

--- a/service-runner.js
+++ b/service-runner.js
@@ -56,7 +56,7 @@ ServiceRunner.prototype.run = function run (conf) {
         self._logger = new Logger(config.logging);
         // And the statsd client
         config.metrics.name = name;
-        self._metrics = makeStatsD(config.metrics);
+        self._metrics = makeStatsD(config.metrics, self._logger);
 
         if (cluster.isMaster && config.num_workers > 0) {
             return self._runMaster();

--- a/service-runner.js
+++ b/service-runner.js
@@ -22,7 +22,7 @@ var os = require('os');
 
 
 var Logger = require('./lib/logger');
-var StatsD = require('./lib/statsd');
+var makeStatsD = require('./lib/statsd');
 
 
 // Disable cluster RR balancing; direct socket sharing has better throughput /
@@ -56,7 +56,7 @@ ServiceRunner.prototype.run = function run (conf) {
         self._logger = new Logger(config.logging);
         // And the statsd client
         config.metrics.name = name;
-        self._metrics = new StatsD(config.metrics);
+        self._metrics = makeStatsD(config.metrics);
 
         if (cluster.isMaster && config.num_workers > 0) {
             return self._runMaster();


### PR DESCRIPTION
- Conform to node-statsd interface
- Add static normalizeNames method right on the statsd instance & don't
  normalize names by default
- Support both txstatsd & statsd backends

See also #6.

@atdt, @d00rman, please have a look. Don't merge before we have a corresponding restbase change lined up.