### PR TITLE
Minor fix: Use config.package.name for the service's name

### DIFF
--- a/service-runner.js
+++ b/service-runner.js
@@ -52,7 +52,7 @@ ServiceRunner.prototype.run = function run (conf) {
     return this.updateConfig(conf)
     .then(function() {
         var config = self.config;
-        var name = config.info && config.info.name || 'service-runner';
+        var name = config.package && config.package.name || 'service-runner';
 
         // Set up the logger
         if (!config.logging.name) {


### PR DESCRIPTION
The information used for logging and metrics is now available in `config.package`, not `config.info`