### PR TITLE
Forcefully restart workers that exceed the heap limit

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -24,7 +24,7 @@ HeapWatch.prototype.watch = function() {
 
     if (usage.heapUsed > this.limit) {
         this.failCount++;
-        if (this.failCount > 5) {
+        if (this.failCount > 3) {
             this.logger.log('fatal/service-runner/heap', {
                 message: 'Heap memory limit exceeded',
                 limit: this.limit,
@@ -34,6 +34,10 @@ HeapWatch.prototype.watch = function() {
             setTimeout(function() {
                 cluster.worker.disconnect();
             }, 1000);
+            // And forcefully exit 60 seconds later
+            setTimeout(function() {
+                process.exit(1);
+            }, 60000);
             return;
         } else {
             this.logger.log('warn/service-runner/heap', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Only calling disconnect() does not reliably exit the worker, especially if
there are open outgoing connections to databases etc. This patch forcefully
exits the process 60 seconds later, after giving ongoing requests enough time
to finish.

In the interest of quicker recovery the fail count is also slightly reduced
from 5 to 3.