### PR TITLE
Keep reporting the stats even when the heap limit has been exceeded

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -11,7 +11,8 @@ function HeapWatch (conf, logger, statsd) {
     this.failCount = 0;
 }
 
-HeapWatch.prototype.watch = function() {
+HeapWatch.prototype.watch = function(doChecklimit) {
+    doChecklimit = doChecklimit === false ? false : true;
     var usage = process.memoryUsage();
 
     // Report memory stats to statsd. Use 'timing' (which isn't really
@@ -21,6 +22,13 @@ HeapWatch.prototype.watch = function() {
     statsd.timing('heap.rss', usage.rss);
     statsd.timing('heap.total', usage.heapTotal);
     statsd.timing('heap.used', usage.heapUsed);
+
+    if (!doChecklimit) {
+        // just report, reset the time-out and return
+        // no checks need to be performed
+        setTimeout(this.watch.bind(this), this.checkInterval, false);
+        return;
+    }
 
     if (usage.heapUsed > this.limit) {
         this.failCount++;
@@ -38,7 +46,7 @@ HeapWatch.prototype.watch = function() {
             setTimeout(function() {
                 process.exit(1);
             }, 60000);
-            return;
+            doChecklimit = false;
         } else {
             this.logger.log('warn/service-runner/heap', {
                 message: 'Heap memory limit temporarily exceeded',
@@ -50,7 +58,7 @@ HeapWatch.prototype.watch = function() {
     } else {
         this.failCount = 0;
     }
-    setTimeout(this.watch.bind(this), this.checkInterval);
+    setTimeout(this.watch.bind(this), this.checkInterval, doChecklimit);
 };
 
 module.exports = HeapWatch;


### PR DESCRIPTION
When a worker exceeds its heap limit, it tries to disconnect, otherwise it is forcibly removed. In either case, no more statistics are being reported, so we cannot know exactly when it has exited and how did the heap size change in the last moments. This PR allows workers to keep reporting their stats until they die even if they have been designated for exclusion.