### PR TITLE
Stats: Normalise the service name and include it in LogStatsD reports

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -18,10 +18,12 @@ function normalizeName (name) {
 
 // A simple console reporter. Useful for development.
 var methods = ['timing','increment','decrement','gauge','unique'];
-function LogStatsD(logger) {
+function LogStatsD(logger, serviceName) {
     var self = this;
+    serviceName = serviceName ? serviceName + '.' : 'service-runner.';
     methods.forEach(function(method) {
         self[method] = function(name, value, samplingInterval) {
+            name = serviceName + name;
             logger.log('trace/metrics', {
                 message: [method, name, value].join(':'),
                 method: method,
@@ -36,10 +38,11 @@ function LogStatsD(logger) {
 // Minimal StatsD wrapper
 function makeStatsD(options, logger) {
     var statsd;
+    var srvName = normalizeName(options.name);
     var statsdOptions = {
         host: options.host,
         port: options.port,
-        prefix: options.name + '.',
+        prefix:  srvName + '.',
         suffix: '',
         txstatsd  : true,
         globalize : false,
@@ -49,7 +52,7 @@ function makeStatsD(options, logger) {
     if (options.type === 'txstatsd') {
         statsd = new TXStatsD(statsdOptions);
     } else if (options.type === 'log') {
-        statsd = new LogStatsD(logger);
+        statsd = new LogStatsD(logger, srvName);
     } else {
         statsd = new StatsD(statsdOptions);
     }


### PR DESCRIPTION
Users can choose whether to normalise their stats name or not. However, the service name itself, prefixed to all statistics, should be normalised. Also, when sending the stats to the logger, make it log the complete statistic name as it would appear in production.