### PR TITLE
Bump version to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Since 0.1.4 has been released, there has been one unpublished change which sets the service name correctly by using the information read from the service's `package.json` instead of using the `info` stanza from `config.yaml` (which does not exist any more).

Note: this PR should be considered after #24 