### PR TITLE
Logger: convert strings to objects with the msg field

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -87,6 +87,9 @@ Logger.prototype.log = function (level, info) {
     if (levelMatch) {
         var logger = this._logger;
         var simpleLevel = levelMatch[1];
+        if (info && typeof info === 'string') {
+            info = {msg: info};
+        }
         if (info && typeof info === 'object') {
             // Got an object
             //

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -87,7 +87,7 @@ Logger.prototype.log = function (level, info) {
     if (levelMatch) {
         var logger = this._logger;
         var simpleLevel = levelMatch[1];
-        if (info && typeof info === 'string') {
+        if (info && info instanceof String) {
             info = {msg: info};
         }
         if (info && typeof info === 'object') {


### PR DESCRIPTION
When a string is passed to the `Logger.log()` method, it gets forwarded as-is to *bunyan*, which places it in the `msg` field of the log entry. However, such log entries lack the `levelPath` field which we usually use for filtering. This PR fixes this issue.

Note: this should be resolved before #25 (or after it, but before publishing the package to npmjs).