### PR TITLE
Set txstatsd option to false by default

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -44,7 +44,7 @@ function makeStatsD(options, logger) {
         port: options.port,
         prefix:  srvName + '.',
         suffix: '',
-        txstatsd  : true,
+        txstatsd  : false,
         globalize : false,
         cacheDns  : true,
         mock      : false


### PR DESCRIPTION
Wikimedia is migrating from txStatsD to statsite, so the txstatsd option should be false by default.
See [T94053](https://phabricator.wikimedia.org/T94053).