### PR TITLE
Fix txstatsd support & release v0.1.7

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -44,10 +44,10 @@ function makeStatsD(options, logger) {
         port: options.port,
         prefix:  srvName + '.',
         suffix: '',
-        txstatsd  : false,
-        globalize : false,
-        cacheDns  : true,
-        mock      : false
+        txstatsd: options.type === 'txstatsd',
+        globalize: false,
+        cacheDns: true,
+        mock: false
     };
     if (options.type === 'txstatsd') {
         statsd = new TXStatsD(statsdOptions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
f5986f5a1e9 broke txstatsd support, and this patch basically reverts it. The
txtstats option was always ignored by the statsd backend library, but in this
patch we are also setting it to false to make things clearer.