### PR TITLE
Fix bugs introduced in 0.1.9 & release v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
- Make sure we return the servers when starting up without forking. This
  somewhat undocumented feature is used by the restbase test runner to access
  the server instance. TODO: Either define that interface properly, or find a
  way to avoid using it.
- Wait for all workers to start up before returning.