### PR TITLE
Use cluster.workers instead of maintaining our own worker registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The cluster module already maintains an object indexing the current workers,
so we don't need to maintain one ourselves. This simplifies the code slightly.