### PR TITLE
Docker: Ensure the HOME and LINK variables are set

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -117,7 +117,9 @@ function create_docker_file() {
     if (opts.uid !== 0) {
         contents += 'RUN groupadd -g ' + opts.gid + ' -r rungroup && ' +
         'useradd -m -r -g rungroup -u ' + opts.uid + ' runuser\n' +
-        'USER runuser\n';
+        'USER runuser\n' + 'ENV HOME=/home/runuser LINK=g++\n';
+    } else {
+        contents += 'HOME=/root/ LINK=g++\n';
     }
 
     if (opts.deploy) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -119,7 +119,7 @@ function create_docker_file() {
         'useradd -m -r -g rungroup -u ' + opts.uid + ' runuser\n' +
         'USER runuser\n' + 'ENV HOME=/home/runuser LINK=g++\n';
     } else {
-        contents += 'HOME=/root/ LINK=g++\n';
+        contents += 'ENV HOME=/root/ LINK=g++\n';
     }
 
     if (opts.deploy) {


### PR DESCRIPTION
When running inside the container, node module dependencies need to be installed. For that, NPM uses a number of environment variables, amongst which HOME and LINK have the biggest impact, in that NPM does not check they are set. Ensure these are set when running our Docker container.