### PR TITLE
Logger improvements

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -27,6 +27,31 @@ function Logger(confOrLogger, args) {
     this.args = args;
 }
 
+var streamConverter = {
+    gelf: function(stream, conf) {
+        // Convert the 'gelf' logger type to a real logger
+        return {
+            type: 'raw',
+            stream: gelf_stream.forBunyan(stream.host,
+                stream.port, stream.options),
+            level: stream.level || conf.level
+        };
+    },
+    stdout: function(stream, conf) {
+        return {
+            stream: process.stdout,
+            level: stream.level || conf.level
+        };
+    },
+    stderr: function(stream, conf) {
+        return {
+            stream: process.stderr,
+            level: stream.level || conf.level
+        };
+    },
+};
+var streamConverterList = Object.keys(streamConverter);
+
 Logger.prototype._processConf = function(conf) {
     var self = this;
     conf = conf || {};
@@ -36,20 +61,14 @@ Logger.prototype._processConf = function(conf) {
         var streams = [];
         conf.streams.forEach(function(stream) {
             var idx;
-            if (stream.type === 'gelf') {
-                // Convert the 'gelf' logger type to a real logger
-                idx = streams.push({
-                    type: 'raw',
-                    stream: gelf_stream.forBunyan(stream.host,
-                        stream.port, stream.options),
-                    level: stream.level || conf.level
-                });
-            } else {
-                idx = streams.push(stream);
+            var convertedStream = stream;
+            if(streamConverterList.indexOf(stream.type) > -1) {
+                convertedStream = streamConverter[stream.type](stream, conf);
             }
+            idx = streams.push(convertedStream);
+            idx--;
             // check that there is a level field and
             // update the minimum level index
-            idx--;
             if(streams[idx].level) {
                 var levelIdx = self._getLevelIndex(streams[idx].level);
                 if(levelIdx < minLevelIdx) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -5,14 +5,18 @@ var bunyan = require('bunyan');
 var gelf_stream = require('gelf-stream');
 
 
+var DEF_LEVEL = 'warn';
+var LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
+var DEF_LEVEL_INDEX = LEVELS.indexOf(DEF_LEVEL);
+
+
 // Simple bunyan logger wrapper
 function Logger(confOrLogger, args) {
     if (confOrLogger.constructor !== Logger) {
         // Create a new root logger
         var conf = this._processConf(confOrLogger);
         this._logger = bunyan.createLogger(conf);
-        var level = conf && conf.level || 'warn';
-        this._levelMatcher = this._levelToMatcher(level);
+        this._levelMatcher = this._levelToMatcher(conf.level);
 
         // Set up handlers for uncaught extensions
         this._setupRootHandlers();
@@ -24,24 +28,47 @@ function Logger(confOrLogger, args) {
 }
 
 Logger.prototype._processConf = function(conf) {
+    var self = this;
+    conf = conf || {};
+    conf.level = conf.level || DEF_LEVEL;
+    var minLevelIdx = this._getLevelIndex(conf.level);
     if (Array.isArray(conf.streams)) {
         var streams = [];
         conf.streams.forEach(function(stream) {
+            var idx;
             if (stream.type === 'gelf') {
                 // Convert the 'gelf' logger type to a real logger
-                streams.push({
+                idx = streams.push({
                     type: 'raw',
                     stream: gelf_stream.forBunyan(stream.host,
-                        stream.port, stream.options)
+                        stream.port, stream.options),
+                    level: stream.level || conf.level
                 });
             } else {
-                streams.push(stream);
+                idx = streams.push(stream);
+            }
+            // check that there is a level field and
+            // update the minimum level index
+            idx--;
+            if(streams[idx].level) {
+                var levelIdx = self._getLevelIndex(streams[idx].level);
+                if(levelIdx < minLevelIdx) {
+                    minLevelIdx = levelIdx;
+                }
+            } else {
+                streams[idx].level = conf.level;
             }
         });
         conf = extend({}, conf);
         conf.streams = streams;
+        conf.level = LEVELS[minLevelIdx];
     }
     return conf;
+};
+
+Logger.prototype._getLevelIndex = function(level) {
+    var idx = LEVELS.indexOf(level);
+    return idx !== -1 ? idx : DEF_LEVEL_INDEX;
 };
 
 Logger.prototype._setupRootHandlers = function() {
@@ -66,11 +93,10 @@ Logger.prototype._setupRootHandlers = function() {
     });
 };
 
-var levels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 Logger.prototype._levelToMatcher = function _levelToMatcher(level) {
-    var pos = levels.indexOf(level);
+    var pos = LEVELS.indexOf(level);
     if (pos !== -1) {
-        return new RegExp('^(' + levels.slice(pos).join('|') + ')(?=\/|$)');
+        return new RegExp('^(' + LEVELS.slice(pos).join('|') + ')(?=\/|$)');
     } else {
         // Match nothing
         return /^$/;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/wikimedia/service-runner",
   "dependencies": {
     "bluebird": "~2.2.2",
-    "bunyan": "^1.3.3",
+    "bunyan": "^1.4.0",
     "core-js": "^0.5.4",
     "extend": "^1.3.0",
     "gelf-stream": "^0.2.4",


### PR DESCRIPTION
The logger uses the `_levelMatcher` private property to determine if a log entry should be logged or not. However, the threshold is set based on `conf.level`, without taking into account individual stream levels. That causes log entries for levels lower than the global level not to be logged in the individual log streams.

This PR performs the check to find the minimum log level to use correctly based on individual stream settings. Additionally, it explicitly appends the `level` property to streams lacking it. The stream conversion has been slightly improved to ease the addition of new stream converters, and converters for `stdout` and `stderr` have been added.

Bug: [T105500](https://phabricator.wikimedia.org/T105500)