### PR TITLE
Logging audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 coverage
 node_modules
 npm-debug.log
+.idea/*
+*.iml

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -129,23 +129,41 @@ Logger.prototype.child = function(args) {
 
 Logger.prototype.log = function(level, info) {
     var levelMatch = this._levelMatcher.exec(level);
-    if (levelMatch) {
+    if (info && levelMatch) {
         var logger = this._logger;
         var simpleLevel = levelMatch[1];
-        if (info && info instanceof String) {
-            info = {msg: info};
+
+        if (info instanceof String) {
+            // Need to convert to primitive
+            info = info.toString();
         }
-        if (info && typeof info === 'object') {
+
+        if (typeof info === 'string') {
+            logger[simpleLevel].call(logger, info);
+        } else if (typeof info === 'object') {
+            var msg;
             // Got an object
             //
+            // If there's a wrapped Error - unwrap and send,
+            // bunyan will properly handle it
+            if (info.err instanceof Error) {
+                info = info.err;
+            } else if (info.msg || info.message || info.info) {
+                msg = info.msg || info.message || info.info
+            }
+
             // Inject the detailed levelpath.
             // 'level' is already used for the numeric level.
             info.levelPath = level;
 
             // Also pass in default parameters
             info = extend(info, this.args);
+            if (msg) {
+                logger[simpleLevel].call(logger, info, msg);
+            } else {
+                logger[simpleLevel].call(logger, info);
+            }
         }
-        logger[simpleLevel].call(logger, info);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -69,15 +69,14 @@ ServiceRunner.prototype.run = function run(conf) {
 
         // Set up the logger
         if (!config.logging.name) {
-            config.logging.name = (config.services && config.services.name) || name;
+            config.logging.name = name;
         }
         self._logger = new Logger(config.logging);
 
         // And the statsd client
         if (!config.metrics.name) {
-            config.metrics.name = (config.services && config.services.name) || name;
+            config.metrics.name = name;
         }
-        self._metrics = makeStatsD(config.metrics, self._logger);
 
         if (cluster.isMaster && config.num_workers > 0) {
             return self._runMaster();
@@ -251,6 +250,8 @@ ServiceRunner.prototype._runWorker = function() {
         heapdump.writeSnapshot();
         process.chdir(cwd);
     });
+
+    self._metrics = makeStatsD(self.config.metrics, self._logger);
 
     // Heap limiting
     // We try to restart workers before they get slow

--- a/service-runner.js
+++ b/service-runner.js
@@ -69,13 +69,13 @@ ServiceRunner.prototype.run = function run(conf) {
 
         // Set up the logger
         if (!config.logging.name) {
-            config.logging.name = name;
+            config.logging.name = (config.services && config.services.name) || name;
         }
         self._logger = new Logger(config.logging);
 
         // And the statsd client
         if (!config.metrics.name) {
-            config.metrics.name = name;
+            config.metrics.name = (config.services && config.services.name) || name;
         }
         self._metrics = makeStatsD(config.metrics, self._logger);
 


### PR DESCRIPTION
Self requires the message in the log to be under the field 'msg', but we name it incorrectly sometimes. This fixes it.

Bug: https://phabricator.wikimedia.org/T108189