### PR TITLE
Implemented heartbeat in service-runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 coverage
 node_modules
 npm-debug.log
+.idea/*
+*.iml

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ num_workers: 1
 
 # Number of milliseconds to wait for a heartbeat from worker before killing
 # and restarting it
-worker_heartbeat_timeout: 500
+worker_heartbeat_timeout: 7500
 
 # Logger info
 logging:

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ services, which will set up this & other things for you.
 # Set to 0 to run everything in a single process without clustering.
 num_workers: 1
 
+# Number of milliseconds to wait for a heartbeat from worker before killing
+# and restarting it
+worker_heartbeat_timeout: 500
+
 # Logger info
 logging:
   level: info

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,10 @@
 # Use 'ncpu' to run as many workers as there are CPU units
 num_workers: ncpu
 
+# Number of milliseconds to wait for a heartbeat from worker before killing
+# and restarting it
+worker_heartbeat_timeout: 1000
+
 # Log error messages and gracefully restart a worker if v8 reports that it
 # uses more heap (note: not RSS) than this many mb.
 worker_heap_limit_mb: 500

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ num_workers: ncpu
 
 # Number of milliseconds to wait for a heartbeat from worker before killing
 # and restarting it
-worker_heartbeat_timeout: 1000
+worker_heartbeat_timeout: 75000
 
 # Log error messages and gracefully restart a worker if v8 reports that it
 # uses more heap (note: not RSS) than this many mb.

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ num_workers: ncpu
 
 # Number of milliseconds to wait for a heartbeat from worker before killing
 # and restarting it
-worker_heartbeat_timeout: 75000
+worker_heartbeat_timeout: 7500
 
 # Log error messages and gracefully restart a worker if v8 reports that it
 # uses more heap (note: not RSS) than this many mb.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -150,10 +150,11 @@ ServiceRunner.prototype._checkHeartbeat = function() {
     var self = this;
     self.interval = setInterval(function() {
         if (!self._shuttingDown && !self._inRollingRestart) {
+            var now = new Date();
             Object.keys(cluster.workers).forEach(function(workerId) {
                 var worker = cluster.workers[workerId];
                 var lastBeat = self.workerHeartbeatTime[worker.process.pid];
-                if (!lastBeat || (!lastBeat.killed && new Date() - lastBeat.time
+                if (!lastBeat || (!lastBeat.killed && now - lastBeat.time
                         > self.config.worker_heartbeat_timeout)) {
                     self._logger.log('error/service-runner/master',
                         'worker ' + worker.process.pid + ' stopped sending heartbeats, killing.');

--- a/service-runner.js
+++ b/service-runner.js
@@ -46,6 +46,8 @@ function ServiceRunner(options) {
 
     // Are we performing a rolling restart?
     this._inRollingRestart = false;
+
+    this.workerHeartbeatTime = {};
 }
 
 ServiceRunner.prototype.run = function run(conf) {
@@ -100,6 +102,7 @@ ServiceRunner.prototype._sanitizeConfig = function(conf, options) {
         // use the number of CPUs
         conf.num_workers = os.cpus().length;
     }
+    conf.timeout = conf.timeout || 1000;
     return conf;
 };
 
@@ -143,6 +146,24 @@ ServiceRunner.prototype.updateConfig = function updateConfig(conf) {
     }
 };
 
+ServiceRunner.prototype._checkHeartbeat = function() {
+    var self = this;
+    self.interval = setInterval(function() {
+        if (!self._shuttingDown && !self._inRollingRestart) {
+            Object.keys(cluster.workers).forEach(function(workerId) {
+                var worker = cluster.workers[workerId];
+                var lastBeat = self.workerHeartbeatTime[worker.process.pid];
+                if (!lastBeat || (!lastBeat.killed && new Date() - lastBeat.time > 3 * self.config.timeout)) {
+                    self._logger.log('error/service-runner/master',
+                        'worker ' + worker.process.pid + ' stopped sending heartbeats, killing.');
+                    self._stopWorker(workerId);
+                    // Don't need to respawn a worker, it will be restarted upon 'exit' event
+                }
+            });
+        }
+    }, self.config.timeout);
+};
+
 ServiceRunner.prototype._runMaster = function() {
     var self = this;
     // Fork workers.
@@ -153,11 +174,12 @@ ServiceRunner.prototype._runMaster = function() {
         if (!self._shuttingDown && !self._inRollingRestart) {
             var exitCode = worker.process.exitCode;
             self._logger.log('error/service-runner/master',
-                    'worker' + worker.process.pid
-                    + 'died (' + exitCode + '), restarting.');
+                    'worker ' + worker.process.pid
+                    + ' died (' + exitCode + '), restarting.');
+            delete self.workerHeartbeatTime[worker.process.pid];
             P.delay(Math.random() * 2000)
             .then(function() {
-                cluster.fork();
+                self._startWorkers(1);
             });
         }
     });
@@ -166,6 +188,9 @@ ServiceRunner.prototype._runMaster = function() {
         self._shuttingDown = true;
         self._logger.log('info/service-runner/master',
                 'master shutting down, killing workers');
+        if (self.interval) {
+            clearInterval(self.interval);
+        }
         cluster.disconnect(function() {
             self._logger.log('info/service-runner/master', 'Exiting master');
             process.exit(0);
@@ -178,19 +203,35 @@ ServiceRunner.prototype._runMaster = function() {
     // Set up rolling restarts
     process.on('SIGHUP', this._rollingRestart.bind(this));
 
-    return this._startWorkers(this.config.num_workers);
+    return this._startWorkers(this.config.num_workers)
+    .then(function(workers) {
+        setTimeout(function() {
+            self._checkHeartbeat();
+        }, 1000);
+        return workers;
+    });
 };
 
-ServiceRunner.prototype._stopWorker = function(id) {
-    var worker = cluster.workers[id];
+ServiceRunner.prototype._stopWorker = function(workerId) {
+    var self = this;
+    var worker = cluster.workers[workerId];
+    self.workerHeartbeatTime[worker.process.pid] = {
+        time: null,
+        killed: true
+    };
     var res = new P(function(resolve) {
         var timeout = setTimeout(function() {
-            worker.kill('SIGKILL');
+            // worker.kill doesn't send a signal immediately, it waits until
+            // worker closes all connections with master. If after a minute
+            // it didn't happen, don't expect it happen ever.
+            process.kill(worker.process.pid, 'SIGKILL');
+            delete self.workerHeartbeatTime[worker.process.pid];
             resolve();
         }, 60000);
         worker.on('disconnect', function() {
             worker.kill('SIGKILL');
             clearTimeout(timeout);
+            delete self.workerHeartbeatTime[worker.process.pid];
             resolve();
         });
     });
@@ -215,25 +256,71 @@ ServiceRunner.prototype._rollingRestart = function() {
     });
 };
 
+/*
+    This is a workaround for the following bug in node:
+    https://github.com/joyent/node/issues/9409
+
+    Shortly, the problem is that a worker is removed by master
+    if it sends 'disconnect' and then it's checked on 'exit'.
+    However, in some cases (for example an infinite CPU loop in worker,
+    'disconnect' may never happen, and master will crash receiving an 'exit'
+ */
+function workAround(worker) {
+    // Take the exit listener node's cluster have set.
+    var listeners = worker.process.listeners('exit')[0];
+    var exit = listeners[Object.keys(listeners)[0]];
+
+    // Take the disconnect litener node's cluster have set.
+    listeners = worker.process.listeners('disconnect')[0];
+    var disconnect = listeners[Object.keys(listeners)[0]];
+
+    // Now replace the exit listener to make sure 'disconnect' was called
+    worker.process.removeListener('exit', exit);
+    worker.process.once('exit', function(exitCode, signalCode) {
+        if (worker.state != 'disconnected') {
+            disconnect();
+        }
+        exit(exitCode, signalCode);
+    });
+}
+
 // Fork off one worker at a time, once the previous worker has finished
 // startup.
-ServiceRunner.prototype._startWorkers = function(remainingWorkers, msg) {
+ServiceRunner.prototype._startWorkers = function(remainingWorkers) {
     var self = this;
-    if (remainingWorkers
-            && (!msg || msg.type === 'startup_finished')) {
+    if (remainingWorkers) {
         var worker = cluster.fork();
         return new P(function(resolve) {
-            worker.on('message', function() {
-                resolve(self._startWorkers(--remainingWorkers));
+            workAround(worker);
+            worker.on('message', function(msg) {
+                if (msg.type === 'startup_finished') {
+                    resolve(self._startWorkers(--remainingWorkers));
+                } else if (msg.type === 'heartbeat') {
+                    self.workerHeartbeatTime[worker.process.pid] = {
+                        time: new Date(),
+                        killed: false
+                    };
+                }
             });
         });
     }
+};
+
+ServiceRunner.prototype._runHeartBeat = function() {
+    // We send heart beat 3 times more frequently than check it
+    // to avoid possibility of wrong restarts
+    this.interval = setInterval(function() {
+        process.send({ type: 'heartbeat' });
+    }, this.config.timeout / 3);
 };
 
 ServiceRunner.prototype._runWorker = function() {
     var self = this;
     // Worker.
     process.on('SIGTERM', function() {
+        if (self.interval) {
+            clearInterval(self.interval);
+        }
         self._logger.log('info/service-runner/worker', 'Worker '
                 + process.pid + ' shutting down');
         process.exit(0);
@@ -292,6 +379,7 @@ ServiceRunner.prototype._runWorker = function() {
         // Signal that this worker finished startup
         if (cluster.isWorker) {
             process.send({type: 'startup_finished'});
+            self._runHeartBeat();
         }
         return res;
     })

--- a/service-runner.js
+++ b/service-runner.js
@@ -153,7 +153,7 @@ ServiceRunner.prototype._checkHeartbeat = function() {
             Object.keys(cluster.workers).forEach(function(workerId) {
                 var worker = cluster.workers[workerId];
                 var lastBeat = self.workerHeartbeatTime[worker.process.pid];
-                if (!lastBeat || (!lastBeat.killed && new Date() - lastBeat.time > 3 * self.config.timeout)) {
+                if (!lastBeat || (!lastBeat.killed && new Date() - lastBeat.time > self.config.timeout)) {
                     self._logger.log('error/service-runner/master',
                         'worker ' + worker.process.pid + ' stopped sending heartbeats, killing.');
                     self._stopWorker(workerId);

--- a/service-runner.js
+++ b/service-runner.js
@@ -296,9 +296,10 @@ ServiceRunner.prototype._startWorkers = function(remainingWorkers) {
                 if (msg.type === 'startup_finished') {
                     resolve(self._startWorkers(--remainingWorkers));
                 } else if (msg.type === 'heartbeat') {
+                    var currentVal = self.workerHeartbeatTime[worker.process.pid];
                     self.workerHeartbeatTime[worker.process.pid] = {
                         time: new Date(),
-                        killed: false
+                        killed: currentVal && currentVal.killed
                     };
                 }
             });

--- a/service-runner.js
+++ b/service-runner.js
@@ -102,7 +102,7 @@ ServiceRunner.prototype._sanitizeConfig = function(conf, options) {
         // use the number of CPUs
         conf.num_workers = os.cpus().length;
     }
-    conf.worker_heartbeat_timeout = conf.worker_heartbeat_timeout || 1000;
+    conf.worker_heartbeat_timeout = conf.worker_heartbeat_timeout || 7500;
     return conf;
 };
 

--- a/service-runner.js
+++ b/service-runner.js
@@ -265,7 +265,7 @@ ServiceRunner.prototype._rollingRestart = function() {
     However, in some cases (for example an infinite CPU loop in worker,
     'disconnect' may never happen, and master will crash receiving an 'exit'
  */
-function workAround(worker) {
+function fixCloseDisconnectListeners(worker) {
     // Take the exit listener node's cluster have set.
     var listeners = worker.process.listeners('exit')[0];
     var exit = listeners[Object.keys(listeners)[0]];
@@ -291,7 +291,7 @@ ServiceRunner.prototype._startWorkers = function(remainingWorkers) {
     if (remainingWorkers) {
         var worker = cluster.fork();
         return new P(function(resolve) {
-            workAround(worker);
+            fixCloseDisconnectListeners(worker);
             worker.on('message', function(msg) {
                 if (msg.type === 'startup_finished') {
                     resolve(self._startWorkers(--remainingWorkers));

--- a/service-runner.js
+++ b/service-runner.js
@@ -299,7 +299,7 @@ ServiceRunner.prototype._startWorkers = function(remainingWorkers) {
                     var currentVal = self.workerHeartbeatTime[worker.process.pid];
                     self.workerHeartbeatTime[worker.process.pid] = {
                         time: new Date(),
-                        killed: currentVal && currentVal.killed
+                        killed: (currentVal && currentVal.killed) || false
                     };
                 }
             });

--- a/service-runner.js
+++ b/service-runner.js
@@ -291,9 +291,12 @@ function fixCloseDisconnectListeners(worker) {
 ServiceRunner.prototype._saveBeat = function(worker) {
     var self = this;
     var currentVal = self.workerHeartbeatTime[worker.process.pid];
+    if (currentVal && currentVal.killed) {
+        return;
+    }
     self.workerHeartbeatTime[worker.process.pid] = {
         time: new Date(),
-        killed: (currentVal && currentVal.killed) || false
+        killed: false
     };
 };
 


### PR DESCRIPTION
The ticket opens multiple questions, but this PR tackles the solutions with heartbeat from workers, which is tracked by master, and if it stops, the an attempt to make a graceful shutdown is made, if that fails, woke is killed and restarted. 

I've been feeling myself as a serial killer today, killing and breaking workers with different kinds of weapons. The biggest problem is CPU-bound loops. If a worker got in some kind of `while(true)`, lots of weird things start happening:
- Obviously, before the fix we couldn't detect it and had it running forever.
- Killing it with `worker.kill('SIGKILL')` doesn't work, because `worker.kill` doesn't send a signal right away, but a disconnect first, which can't finish for a worker that's in a loop.
- Killing a worker that got to a CPU-intense loop with console `kill -9 <pid>` crashes the whole server!!! (including master). The problem is this bug in node: https://github.com/joyent/node/issues/9409 Master's notion of workers is updated on `disconnect` message and checked on `exit`. This was fixed by a dirty hack which replaces node's listeners on a worker, but the hack works and it looks pretty stable.

I've run the service with the fix for quite some time, performed some benchmarking, killing workers in the process, and everything looks stable. What are your opinions on this? Do we want a dirty hack? 

Bug: https://phabricator.wikimedia.org/T90362