### PR TITLE
Make service-runner more Unix-daemon-friendly

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -167,5 +167,14 @@ Logger.prototype.log = function(level, info) {
     }
 };
 
+Logger.prototype.close = function() {
+    var self = this;
+    self._logger.streams.filter(function(stream) {
+        return stream.type === 'file';
+    }).forEach(function(stream) {
+        stream.stream.end();
+    });
+};
+
 
 module.exports = Logger;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -252,6 +252,11 @@ ServiceRunner.prototype._runMaster = function() {
     // Set up rolling restarts
     process.on('SIGHUP', function() {
         return self.updateConfig()
+        .then(function() {
+            // Recreate loggers
+            self._logger.close();
+            self._logger = new Logger(self.config.logging);
+        })
         .then(self._rollingRestart.bind(self));
     });
 


### PR DESCRIPTION
The config part is strait forward. With the logger part - we don't need to close console or gelf streams, and for file streams bunyan actually exposes a node's Writable Stream object, so it appeared to be easy to close the fd.

Bug: https://phabricator.wikimedia.org/T109727