### PR TITLE
Don't discard most logging info in logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -142,15 +142,12 @@ Logger.prototype.log = function(level, info) {
             logger[simpleLevel].call(logger, info);
         } else if (typeof info === 'object') {
             var msg;
-            // Got an object
+            // Got an object.
             //
-            // If there's a wrapped Error - unwrap and send,
-            // bunyan will properly handle it
-            if (info.err instanceof Error) {
-                info = info.err;
-            } else if (info.msg || info.message || info.info) {
-                msg = info.msg || info.message || info.info
-            }
+            // We don't want to use bunyan's default error handling, as that
+            // drops most attributes on the floor. Instead, make sure we have
+            // a msg, and pass that separately to bunyan.
+            msg = info.msg || info.message || info.info || '' + info;
 
             // Inject the detailed levelpath.
             // 'level' is already used for the numeric level.
@@ -158,11 +155,7 @@ Logger.prototype.log = function(level, info) {
 
             // Also pass in default parameters
             info = extend(info, this.args);
-            if (msg) {
-                logger[simpleLevel].call(logger, info, msg);
-            } else {
-                logger[simpleLevel].call(logger, info);
-            }
+            logger[simpleLevel].call(logger, info, msg);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
bff5450 changed the logic to only log a wrapped error instance & drop all
other information on the floor. This is problematic, as this means that
details like internal requests don't make it into the logs, greatly
complicating debugging.

This patch restores the previous behavior of logging all provided information,
but also makes sure that the msg parameter is provided as a positional
parameter to bunyan.