### PR TITLE
Update dependencies' versions and release v0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -29,21 +29,14 @@
   },
   "homepage": "https://github.com/wikimedia/service-runner",
   "dependencies": {
-    "bluebird": "~2.2.2",
-    "bunyan": "^1.4.0",
-    "core-js": "^0.5.4",
-    "extend": "^1.3.0",
-    "gelf-stream": "^0.2.4",
-    "js-yaml": "~3.2.2",
+    "bluebird": "~2.8.2",
+    "bunyan": "^1.5.1",
+    "core-js": "^1.1.4",
+    "extend": "^3.0.0",
+    "gelf-stream": "^1.0.3",
+    "js-yaml": "^3.4.2",
     "node-statsd": "^0.1.1",
-    "node-txstatsd": "^0.1.5",
-    "yargs": "^3.7.2"
-  },
-  "devDependencies": {
-    "mocha": "~1.x.x",
-    "mocha-jshint": "0.0.9",
-    "istanbul": "0.3.5",
-    "mocha-lcov-reporter": "0.0.1",
-    "coveralls": "2.11.2"
+    "node-txstatsd": "^0.1.6",
+    "yargs": "^3.24.0"
   }
 }


### PR DESCRIPTION
- update node module dependencies' versions
- remove `devDependencies` as they are not needed
- bump version to v0.2.5

This has been tested with RESTBase, Citoid and MobileApps