### PR TITLE
Added a debugging log stream for pretty console logging

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -65,7 +65,7 @@ var streamConverter = {
         return {
             stream: prettyStream,
             level: stream.level || conf.level
-        }
+        };
     },
     stderr: function(stream, conf) {
         return {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,7 +4,6 @@ var extend = require('extend');
 var bunyan = require('bunyan');
 var gelfStream = require('gelf-stream');
 var syslogStream = require('bunyan-syslog-udp');
-var PrettyStream = require('bunyan-prettystream');
 
 var DEF_LEVEL = 'warn';
 var LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
@@ -60,12 +59,18 @@ var streamConverter = {
         };
     },
     debug: function(stream, conf) {
-        var prettyStream = new PrettyStream();
-        prettyStream.pipe(process.stdout);
-        return {
-            stream: prettyStream,
-            level: stream.level || conf.level
-        };
+        try {
+            var PrettyStream = require('bunyan-prettystream');
+            var prettyStream = new PrettyStream();
+            prettyStream.pipe(process.stdout);
+            return {
+                stream: prettyStream,
+                level: stream.level || conf.level
+            };
+        } catch (e) {
+            console.log('Could not set up pretty logging stream', e);
+            return streamConverter.stdout(stream, conf);
+        }
     },
     stderr: function(stream, conf) {
         return {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,7 +4,7 @@ var extend = require('extend');
 var bunyan = require('bunyan');
 var gelfStream = require('gelf-stream');
 var syslogStream = require('bunyan-syslog-udp');
-
+var PrettyStream = require('bunyan-prettystream');
 
 var DEF_LEVEL = 'warn';
 var LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
@@ -58,6 +58,14 @@ var streamConverter = {
             stream: process.stdout,
             level: stream.level || conf.level
         };
+    },
+    debug: function(stream, conf) {
+        var prettyStream = new PrettyStream();
+        prettyStream.pipe(process.stdout);
+        return {
+            stream: prettyStream,
+            level: stream.level || conf.level
+        }
     },
     stderr: function(stream, conf) {
         return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -42,6 +42,7 @@
   "devDependencies": {
     "mocha": "^2.4.5",
     "mocha-jshint": "^2.3.0",
-    "mocha-jscs": "^4.2.0"
+    "mocha-jscs": "^4.2.0",
+    "bunyan-prettystream": "^0.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,6 @@
     "mocha": "^2.4.5",
     "mocha-jshint": "^2.3.0",
     "mocha-jscs": "^4.2.0",
-    "bunyan-prettystream": "^0.1.3"
+    "bunyan-prettystream": "git+https://github.com/hadfieldn/node-bunyan-prettystream#master"
   }
 }


### PR DESCRIPTION
In [this ticket](https://phabricator.wikimedia.org/T113207) an option for pretty human-readable console logs for service-runner is requested. I find reading JSON logs painful too, so here's a `debug` stream that outputs nice color-coded logs with nice expanded stack-traces etc. 

Usage: simply add a `type: debug` stream to logger config.