### PR TITLE
Added a try/catch on heapdump require

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -59,12 +59,17 @@ Worker.prototype._run = function() {
     // For node 0.6/0.8: npm install heapdump@0.1.0
     // For 0.10: npm install heapdump
     process.on('SIGUSR2', function() {
-        var heapdump = require('heapdump');
-        var cwd = process.cwd();
-        console.error('SIGUSR2 received! Writing snapshot.');
-        process.chdir('/tmp');
-        heapdump.writeSnapshot();
-        process.chdir(cwd);
+        try {
+            var heapdump = require('heapdump');
+            var cwd = process.cwd();
+            console.error('SIGUSR2 received! Writing snapshot.');
+            process.chdir('/tmp');
+            heapdump.writeSnapshot();
+            process.chdir(cwd);
+        } catch (e) {
+            self._logger.log('warn/service-runner/worker',
+                'Worker ' + process.pid + ' received SIGUSR2, but heapdump is not installed');
+        }
     });
 
     self._metrics = makeStatsD(self.config.metrics, self._logger);


### PR DESCRIPTION
As we don't require `heapdump` as a production dependency, it's totally possible that it wouldn't be installed. In that case `SIGUSR2` will simply crash the worker. This PR adds a try/catch for heap dump require, so that a worker could log a warning and continue execution.