### PR TITLE
Use yaml.dump, and bump version to v0.2.8

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -169,7 +169,7 @@ Master.prototype._startWorkers = function(remainingWorkers) {
             fixCloseDisconnectListeners(worker);
             worker.send({
                 type: 'config',
-                body: yaml.safeDump(self.config)
+                body: yaml.dump(self.config)
             });
             worker.on('message', function(msg) {
                 if (msg.type === 'startup_finished') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The yaml.dump would explode on an undefined value, which caused the aqs
service to fail to start. Yaml.dump lets through undefined values normally, so
startup will succeed.