### PR TITLE
Bug fix: Adjust test for _basePath

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -30,8 +30,8 @@ function BaseService(options) {
     this._metrics = null;
 
     // Figure out the base path
-    this._basePath = /\/node_modules\/service-runner$/.test(__dirname) ?
-        path.resolve(__dirname + '/../../') : path.resolve('./');
+    this._basePath = /\/node_modules\/service-runner/lib$/.test(__dirname) ?
+        path.resolve(__dirname + '/../../../') : path.resolve('./');
 }
 
 BaseService.prototype.run = function run(conf) {

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -30,7 +30,7 @@ function BaseService(options) {
     this._metrics = null;
 
     // Figure out the base path
-    this._basePath = /\/node_modules\/service-runner/lib$/.test(__dirname) ?
+    this._basePath = /\/node_modules\/service-runner\/lib$/.test(__dirname) ?
         path.resolve(__dirname + '/../../../') : path.resolve('./');
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Before the master/worker split, __dirname was pointing to node_modules/service-runner, but with the split, the test is actually happening in node_modules/service-runner/lib, so adjust the test and path resolution accordingly.