### PR TITLE
Added support for simple expressions in num_workers config

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -159,8 +159,8 @@ BaseService.prototype._sanitizeConfig = function(conf, options) {
         conf.num_workers = options.num_workers;
     }
     if (typeof conf.num_workers !== 'number') {
-        if (/^(?:(?:ncpu)|[\s\(\)\+\-\*\/\.\d])+$/.test(conf.num_workers)) {
-            // It's safe to make a eval here, the input format is checked
+        if (/^(?:(?:ncpu[\s\)\+\-\*\/])|[\s\(\)\+\-\*\/\.\d])+(?:ncpu)?$/.test(conf.num_workers)) {
+            // It's safe to make an eval here, the input format is checked
             /* jshint evil:true */
             var num = eval(conf.num_workers.replace(/ncpu/g, os.cpus().length));
             conf.num_workers = Math.floor(num);

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -159,11 +159,11 @@ BaseService.prototype._sanitizeConfig = function(conf, options) {
         conf.num_workers = options.num_workers;
     }
     if (typeof conf.num_workers !== 'number') {
-        if (/^ncpu\s*[\*\+\-\/]\s*\d+(?:\.\d+)?$/.test(conf.num_workers)) {
+        if (/^(?:(?:ncpu)|[\s\(\)\+\-\*\/\.\d])+$/.test(conf.num_workers)) {
             // It's safe to make a eval here, the input format is checked
             /* jshint evil:true */
-            var num = eval(conf.num_workers.replace('ncpu', os.cpus().length));
-            conf.num_workers = Math.round(num);
+            var num = eval(conf.num_workers.replace(/ncpu/g, os.cpus().length));
+            conf.num_workers = Math.floor(num);
         } else {
             // use the number of CPUs
             conf.num_workers = os.cpus().length;

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -157,9 +157,17 @@ BaseService.prototype._sanitizeConfig = function(conf, options) {
         // the number of workers has been supplied
         // on the command line, so honour that
         conf.num_workers = options.num_workers;
-    } else if (conf.num_workers === 'ncpu' || typeof conf.num_workers !== 'number') {
-        // use the number of CPUs
-        conf.num_workers = os.cpus().length;
+    }
+    if (typeof conf.num_workers !== 'number') {
+        if (/^ncpu\s*[\*\+\-\/]\s*\d+(?:\.\d+)?$/.test(conf.num_workers)) {
+            // It's safe to make a eval here, the input format is checked
+            /* jshint evil:true */
+            var num = eval(conf.num_workers.replace('ncpu', os.cpus().length));
+            conf.num_workers = Math.round(num);
+        } else {
+            // use the number of CPUs
+            conf.num_workers = os.cpus().length;
+        }
     }
     conf.worker_heartbeat_timeout = conf.worker_heartbeat_timeout || 7500;
     return conf;


### PR DESCRIPTION
A couple of small improvements: 
1. If `ncpu` is supplied from the console - parse and use it.
2. Added support for simple expressions like `ncpu / 2`. Eval should be safe here, as an input is checked with a restrictive regex, and also the input is provided from a config, so it's controlled by us.

Bug: https://phabricator.wikimedia.org/T108888