### PR TITLE
Don't kill a worker on heap limit exceeded when num_workers = 0

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -30,15 +30,18 @@ HeapWatch.prototype.watch = function() {
                 limit: this.limit,
                 memoryUsage: usage
             });
-            // Delay the restart long enough to allow the log to be sent out
-            setTimeout(function() {
-                cluster.worker.disconnect();
-            }, 1000);
-            // And forcefully exit 60 seconds later
-            setTimeout(function() {
-                process.exit(1);
-            }, 60000);
-            return;
+            // Don't try to restart a worker when num_workers = 0, just log a problem
+            if (cluster.isWorker) {
+                // Delay the restart long enough to allow the log to be sent out
+                setTimeout(function() {
+                    cluster.worker.disconnect();
+                }, 1000);
+                // And forcefully exit 60 seconds later
+                setTimeout(function() {
+                    process.exit(1);
+                }, 60000);
+                return;
+            }
         } else {
             this.logger.log('warn/service-runner/heap', {
                 message: 'Heap memory limit temporarily exceeded',


### PR DESCRIPTION
When `num_workers = 0` it doesn't make sense to kill a `worker` if the heap limit exceeded, so just log a problem and continue.  And the killing code was buggy.

Bug: https://phabricator.wikimedia.org/T107271