### PR TITLE
Delay exiting on failure to let the logger do its work

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -121,7 +121,13 @@ Worker.prototype._run = function() {
     })
     .catch(function(e) {
         self._logger.log('fatal/service-runner/worker', e);
-        process.exit(1);
+        // Give the logger some time to do its work before exiting
+        // synchronously.
+        // XXX: Consider returning a Promise from logger.log.
+        return P.delay(1000)
+        .then(function() {
+            process.exit(1);
+        });
     });
 };
 


### PR DESCRIPTION
`process.exit` is synchronous, while logging is async. This means that we need
to wait until the logger has logged a failure before exiting. Currently, the
logger does not support waiting for completion, so we use a 1s delay as a
work-around.