### PR TITLE
Docker script: Ignore errors for `git rm -r node_modules`

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -337,7 +337,7 @@ function updateDeploy() {
             opts.commit_msg += 'xxxxxxx Update node module dependencies\n';
         }
         // a rebuild is needed, start by removing the existing modules
-        return promisedGit(['rm', '-r', 'node_modules'])
+        return promisedGit(['rm', '-r', 'node_modules'], { ignoreErr: true })
         .then(function() {
             return promisedSpawn(['rm', '-rf', 'node_modules'], { capture: true, ignoreErr: true });
         }).then(function() {


### PR DESCRIPTION
If the node_modules directory has already been removed, building the repository shouldn't fail, so it is safe to ignore this specific error.