### PR TITLE
Docker script: De-duplicate module dependencies

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -137,7 +137,7 @@ function createDockerFile() {
         contents += 'RUN mkdir /opt/service\n' +
             'ADD . /opt/service\n' +
             'WORKDIR /opt/service\n' +
-            'RUN npm install\n';
+            'RUN npm install && npm dedupe\n';
     }
 
     if (opts.uid !== 0) {
@@ -149,7 +149,8 @@ function createDockerFile() {
     }
 
     if (opts.deploy) {
-        contents += 'CMD /usr/bin/npm install --production && /usr/bin/npm install heapdump';
+        contents += 'CMD /usr/bin/npm install --production && '
+            + '/usr/bin/npm install heapdump && npm dedupe';
     } else if (opts.tests) {
         contents += 'CMD ["/usr/bin/npm", "test"]';
     } else if (opts.coverage) {


### PR DESCRIPTION
Most packages use ^ and/or ~ to designate suitable dependencies. Coupling that with npm's way of searching for packages recursively up the path means that there is great benefit in de-duplicating all of service's packages when running in the container. Most notably, this vastly simplifies and minimises the deploy repository's footprint.