### PR TITLE
Allow to use alternative node versions

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -134,22 +134,21 @@ function createDockerFile() {
         ' && rm -rf /var/lib/apt/lists/*\n';
 
     var nodeVersion = pkg.deploy.node;
+    var npmCommand = 'npm';
     if (nodeVersion && nodeVersion !== 'system') {
         var nvmDownloadURI = 'https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh';
         contents += 'ENV NVM_DIR /usr/local/nvm\n';
         contents += 'RUN wget -qO- ' + nvmDownloadURI + ' | bash' +
                     ' && . $NVM_DIR/nvm.sh' +
-                    ' && nvm install ' + nodeVersion +
-                    ' && nvm use ' + nodeVersion + '\n';
-        contents += 'ENV NODE_PATH=$NVM_DIR/v' + nodeVersion + '/lib/node_modules ' +
-                    'PATH=$NVM_DIR/v' + nodeVersion + '/bin:$PATH\n';
+                    ' && nvm install ' + nodeVersion + '\n';
+        npmCommand = '. $NVM_DIR/nvm.sh && nvm use ' + nodeVersion + ' && npm';
     }
 
     if (!opts.deploy) {
         contents += 'RUN mkdir /opt/service\n' +
             'ADD . /opt/service\n' +
             'WORKDIR /opt/service\n' +
-            'RUN npm install\n';
+            'RUN ' + npmCommand + ' install\n';
     }
 
     if (opts.uid !== 0) {
@@ -161,13 +160,13 @@ function createDockerFile() {
     }
 
     if (opts.deploy) {
-        contents += 'CMD npm install --production && npm install heapdump';
+        contents += 'CMD ' + npmCommand + ' install --production && npm install heapdump';
     } else if (opts.tests) {
-        contents += 'CMD ["npm", "test"]';
+        contents += 'CMD ' + npmCommand + ' test';
     } else if (opts.coverage) {
-        contents += 'CMD ["npm", "run-script", "coverage"]';
+        contents += 'CMD ' + npmCommand + ' run-script coverage';
     } else {
-        contents += 'CMD ["npm", "start"]';
+        contents += 'CMD ' + npmCommand + ' start';
     }
 
     return fs.writeFileAsync('Dockerfile', contents);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -148,7 +148,7 @@ function createDockerFile() {
         contents += 'RUN mkdir /opt/service\n' +
             'ADD . /opt/service\n' +
             'WORKDIR /opt/service\n' +
-            'RUN ' + npmCommand + ' install && && npm dedupe\n';
+            'RUN ' + npmCommand + ' install && npm dedupe\n';
     }
 
     if (opts.uid !== 0) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -97,7 +97,7 @@ function createDockerFile() {
 
     var contents = '';
     var baseImg;
-    var extraPkgs = ['nodejs', 'nodejs-legacy', 'npm', 'git'];
+    var extraPkgs = ['nodejs', 'nodejs-legacy', 'npm', 'git', 'wget'];
 
     // set some defaults
     if (!pkg.deploy) {
@@ -130,14 +130,26 @@ function createDockerFile() {
     }
 
     contents = 'FROM ' + baseImg + '\n' +
-        'RUN apt-get update && apt-get install -y ' + extraPkgs.join(' ') +
+        'RUN apt-get update --fix-missing && apt-get install -y ' + extraPkgs.join(' ') +
         ' && rm -rf /var/lib/apt/lists/*\n';
+
+    var nodeVersion = pkg.deploy.node;
+    if (nodeVersion && nodeVersion !== 'system') {
+        var nvmDownloadURI = 'https://raw.githubusercontent.com/creationix/nvm/v0.29.0/install.sh';
+        contents += 'ENV NVM_DIR /usr/local/nvm\n';
+        contents += 'RUN wget -qO- ' + nvmDownloadURI + ' | bash' +
+                    ' && . $NVM_DIR/nvm.sh' +
+                    ' && nvm install ' + nodeVersion +
+                    ' && nvm use ' + nodeVersion + '\n';
+        contents += 'ENV NODE_PATH=$NVM_DIR/v' + nodeVersion + '/lib/node_modules ' +
+                    'PATH=$NVM_DIR/v' + nodeVersion + '/bin:$PATH\n';
+    }
 
     if (!opts.deploy) {
         contents += 'RUN mkdir /opt/service\n' +
             'ADD . /opt/service\n' +
             'WORKDIR /opt/service\n' +
-            'RUN npm install && npm dedupe\n';
+            'RUN rm -rf node_modules; npm install\n';
     }
 
     if (opts.uid !== 0) {
@@ -149,14 +161,13 @@ function createDockerFile() {
     }
 
     if (opts.deploy) {
-        contents += 'CMD /usr/bin/npm install --production && '
-            + '/usr/bin/npm install heapdump && npm dedupe';
+        contents += 'CMD npm install --production && npm install heapdump';
     } else if (opts.tests) {
-        contents += 'CMD ["/usr/bin/npm", "test"]';
+        contents += 'CMD ["npm", "test"]';
     } else if (opts.coverage) {
-        contents += 'CMD ["/usr/bin/npm", "run-script", "coverage"]';
+        contents += 'CMD ["npm", "run-script", "coverage"]';
     } else {
-        contents += 'CMD ["/usr/bin/npm", "start"]';
+        contents += 'CMD ["npm", "start"]';
     }
 
     return fs.writeFileAsync('Dockerfile', contents);

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -130,7 +130,7 @@ function createDockerFile() {
     }
 
     contents = 'FROM ' + baseImg + '\n' +
-        'RUN apt-get update --fix-missing && apt-get install -y ' + extraPkgs.join(' ') +
+        'RUN apt-get update && apt-get install -y ' + extraPkgs.join(' ') +
         ' && rm -rf /var/lib/apt/lists/*\n';
 
     var nodeVersion = pkg.deploy.node;
@@ -149,7 +149,7 @@ function createDockerFile() {
         contents += 'RUN mkdir /opt/service\n' +
             'ADD . /opt/service\n' +
             'WORKDIR /opt/service\n' +
-            'RUN rm -rf node_modules; npm install\n';
+            'RUN npm install\n';
     }
 
     if (opts.uid !== 0) {

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -148,7 +148,7 @@ function createDockerFile() {
         contents += 'RUN mkdir /opt/service\n' +
             'ADD . /opt/service\n' +
             'WORKDIR /opt/service\n' +
-            'RUN ' + npmCommand + ' install\n';
+            'RUN ' + npmCommand + ' install && && npm dedupe\n';
     }
 
     if (opts.uid !== 0) {
@@ -160,7 +160,8 @@ function createDockerFile() {
     }
 
     if (opts.deploy) {
-        contents += 'CMD ' + npmCommand + ' install --production && npm install heapdump';
+        contents += 'CMD ' + npmCommand + ' install --production && ' +
+            'npm install heapdump && npm dedupe';
     } else if (opts.tests) {
         contents += 'CMD ' + npmCommand + ' test';
     } else if (opts.coverage) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.2.12",
+  "version": "0.3.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Allow docker script to use configurable node versions for build/deploy/test.

Bug: https://phabricator.wikimedia.org/T114399