### PR TITLE
Better error handling on promised git

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -8,7 +8,7 @@ var yaml = require('js-yaml');
 var P = require('bluebird');
 var fs = P.promisifyAll(require('fs'));
 var path = require('path');
-
+var util = require('util');
 
 // Info from the package definition
 var pkg;
@@ -26,6 +26,15 @@ var name;
 
 // Holds the curently running process
 var child;
+
+function SpawnError(code, message) {
+    Error.call(this);
+    Error.captureStackTrace(this, SpawnError);
+    this.name = this.constructor.name;
+    this.message = message;
+    this.code = code;
+}
+util.inherits(SpawnError, Error);
 
 
 /**
@@ -47,6 +56,7 @@ function promisedSpawn(args, options) {
     var promise = new P(function(resolve, reject) {
         var argOpts = options.capture ? undefined : { stdio: 'inherit' };
         var ret = '';
+        var err = '';
         if (opts.verbose) {
             console.log('# RUNNING: ' + args.join(' ') + '\n' +
                 '  (in ' + process.cwd() + ')');
@@ -55,6 +65,9 @@ function promisedSpawn(args, options) {
         if (options.capture) {
             child.stdout.on('data', function(data) {
                 ret += data.toString();
+            });
+            child.stderr.on('data', function(data) {
+                err += data.toString();
             });
         }
         child.on('close', function(code) {
@@ -65,7 +78,7 @@ function promisedSpawn(args, options) {
                 if (options.ignoreErr) {
                     resolve(ret);
                 } else {
-                    reject(code, ret);
+                    reject(new SpawnError(code, err.trim()));
                 }
             } else {
                 resolve(ret);
@@ -74,12 +87,14 @@ function promisedSpawn(args, options) {
     });
 
     if (options.useErrHandler || options.errMessage) {
-        promise = promise.catch(function(code, ret) {
+        promise = promise.catch(function(err) {
             if (options.errMessage) {
                 console.error('ERROR: ' + options.errMessage.split("\n").join("\nERROR: "));
             }
-            console.error('ERROR: ' + args.slice(0, 2).join(' ') + ' exited with code ' + code);
-            process.exit(code);
+            console.error('ERROR: ' + args.slice(0, 2).join(' ')
+                + ' exited with code ' + err.code
+                + ' and message ' + err.message);
+            process.exit(err.code);
         });
     }
 
@@ -236,6 +251,7 @@ function updateDeploy() {
         Array.prototype.push.apply(argsArr, args);
         options = options || {};
         options.capture = true;
+        options.useErrHandler = true;
         return promisedSpawn(argsArr, options);
     }
 

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -91,9 +91,12 @@ function promisedSpawn(args, options) {
             if (options.errMessage) {
                 console.error('ERROR: ' + options.errMessage.split("\n").join("\nERROR: "));
             }
-            console.error('ERROR: ' + args.slice(0, 2).join(' ')
-                + ' exited with code ' + err.code
-                + ' and message ' + err.message);
+            var msg = 'ERROR: ' + args.slice(0, 2).join(' ')
+                + ' exited with code ' + err.code;
+            if (err.message) {
+                msg += ' and message ' + err.message;
+            }
+            console.error(msg);
             process.exit(err.code);
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Some issues with error handling on process spawn:
- `P.reject()` takes one argument, not two. And better if the argument is an `Error` instance, then the stack trace is more valid
- Notification about error in spawned process should contain `stderr`, not `stdout`
- On git spawn, we need error handlers, or the error becomes unhanded, which's reported by bluebird.

Bug: https://phabricator.wikimedia.org/T116873