### PR TITLE
Docker script: Make deploy repo's origin configurable

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -212,7 +212,7 @@ function buildImg() {
  * Starts the container and returns once it has finished executing
  *
  * @param {Array} args the array of extra parameters to pass, optional
- * @param {Boolean} whether to keep the ports hidden inside the container, optional
+ * @param {Boolean} hidePorts whether to keep the ports hidden inside the container, optional
  * @return {Promise} the promise starting the container
  */
 function startContainer(args, hidePorts) {
@@ -273,24 +273,29 @@ function updateDeploy() {
     }
 
     // check if there is an alternative repo name defined
-    return promisedGit(['config', 'deploy.name'], { ignoreErr: true })
-    .then(function(name) {
-        opts.name = name ? name : pkg.name;
+    return P.props({
+        name: promisedGit(['config', 'deploy.name'], { ignoreErr: true }),
+        remote: promisedGit(['config', 'deploy.remote'], { ignoreErr: true })
+    }).then(function(props) {
+        opts.name = props.name ? props.name : pkg.name;
+        opts.remote_name = props.remote ? props.remote : 'origin';
+        opts.remote_branch = opts.remote_name + '/master';
         // we need to CHDIR into the deploy dir for subsequent operations
         process.chdir(opts.dir);
         return chainedPgit([
             // make sure we are on master
             ['checkout', 'master'],
             // fetch any possible updates
-            ['fetch', 'origin'],
+            ['fetch', opts.remote_name],
             // work on a topic branch
-            ['checkout', '-B', 'sync-repo', 'origin/master'],
+            ['checkout', '-B', 'sync-repo', opts.remote_branch],
             // check if the submodule is present
             ['submodule', 'status']
         ]);
     }).then(function(list) {
         if (list) {
             // the submodule is present
+            // in submodule the remote is always called 'origin', so ignore opts.
             opts.submodule = list.split(' ')[1];
             // update it fully
             return promisedGit(['submodule', 'update', '--init'])

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The deploy repo origin might be name differently from default `origin`. A new git config param `deploy.remote` could be used to control it. 

Bug: https://phabricator.wikimedia.org/T116873