### PR TITLE
Logging: Support special handling for 'interesting' events

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ logging:
   # Map keys correspond to the event names, specified in the log levels
   # For example, in 'info/webrequest', the event name is 'webrequest'.
   # Map values specify the probability for such events to be logged
-  # disregards the configured logging level.
+  # regardless of the configured logging level.
   log_components:
     webrequest: 0.2
   streams:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ worker_heartbeat_timeout: 7500
 # Logger info
 logging:
   level: info
+  # Sets up sample logging for some 'interesting' events.
+  # Map keys correspond to the event names, specified in the log levels
+  # For example, in 'info/webrequest', the event name is 'webrequest'.
+  # Map values specify the probability for such events to be logged
+  # disregards the configured logging level.
+  log_components:
+    webrequest: 0.2
   streams:
   # Use gelf-stream -> logstash
   - type: gelf

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -23,7 +23,7 @@ function Logger(confOrLogger, args) {
         self._levelMatcher = this._levelToMatcher(conf.level);
 
         // For each specially logged component we need to create
-        // a child logger that accepts everything disregards the level
+        // a child logger that accepts everything regardless of the level
         self._componentLoggers = {};
         Object.keys(self._log_components).forEach(function(component) {
             self._componentLoggers[component] = self._logger.child({
@@ -177,7 +177,7 @@ Logger.prototype._levelToMatcher = function _levelToMatcher(level) {
  * @private
  */
 Logger.prototype._getComponentLogConfig = function(level) {
-    if (level && this._log_components) {
+    if (level && Object.keys(this._log_components).length) {
         var slashIndex = level.indexOf('/');
         if (slashIndex > 0) {
             var component = level.substr(slashIndex + 1);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -13,17 +13,32 @@ var DEF_LEVEL_INDEX = LEVELS.indexOf(DEF_LEVEL);
 
 // Simple bunyan logger wrapper
 function Logger(confOrLogger, args) {
+    var self = this;
     if (confOrLogger.constructor !== Logger) {
         // Create a new root logger
         var conf = this._processConf(confOrLogger);
-        this._logger = bunyan.createLogger(conf);
-        this._levelMatcher = this._levelToMatcher(conf.level);
+        self._log_components = conf.log_components || {};
+        delete conf.log_components;
+        self._logger = bunyan.createLogger(conf);
+        self._levelMatcher = this._levelToMatcher(conf.level);
+
+        // For each specially logged component we need to create
+        // a child logger that accepts everything disregards the level
+        self._componentLoggers = {};
+        Object.keys(self._log_components).forEach(function(component) {
+            self._componentLoggers[component] = self._logger.child({
+                component: component,
+                level: bunyan.TRACE
+            });
+        });
 
         // Set up handlers for uncaught extensions
-        this._setupRootHandlers();
+        self._setupRootHandlers();
     } else {
-        this._logger = confOrLogger._logger;
-        this._levelMatcher = confOrLogger._levelMatcher;
+        self._log_components = confOrLogger._log_components;
+        self._logger = confOrLogger._logger;
+        self._levelMatcher = confOrLogger._levelMatcher;
+        self._componentLoggers = confOrLogger._componentLoggers;
     }
     this.args = args;
 }
@@ -67,6 +82,7 @@ var streamConverterList = Object.keys(streamConverter);
 Logger.prototype._processConf = function(conf) {
     var self = this;
     conf = conf || {};
+    conf = extend({}, conf);
     conf.level = conf.level || DEF_LEVEL;
     var minLevelIdx = this._getLevelIndex(conf.level);
     if (Array.isArray(conf.streams)) {
@@ -90,7 +106,6 @@ Logger.prototype._processConf = function(conf) {
                 streams[idx].level = conf.level;
             }
         });
-        conf = extend({}, conf);
         conf.streams = streams;
         conf.level = LEVELS[minLevelIdx];
     }
@@ -150,6 +165,52 @@ Logger.prototype._levelToMatcher = function _levelToMatcher(level) {
     }
 };
 
+/**
+ * Parses the provided logging level for a log component,
+ * matches it with the configured specially logged components.
+ *
+ * If the message should be logged, returns an object with bunyan log level
+ * and a specialized logger for the given component, otherwise returns undefined
+ *
+ * @param {String} level a logging level
+ * @returns {Object|undefined} corresponding bunyan log level and a specialized logger
+ * @private
+ */
+Logger.prototype._getComponentLogConfig = function(level) {
+    if (level && this._log_components) {
+        var slashIndex = level.indexOf('/');
+        if (slashIndex > 0) {
+            var component = level.substr(slashIndex + 1);
+            var logProbability = this._log_components[component];
+            if (logProbability && (Math.random() < logProbability)) {
+                return {
+                    level: level.substring(0, slashIndex),
+                    logger: this._componentLoggers[component]
+                };
+            }
+        }
+    }
+    return undefined;
+};
+
+/**
+ * Parses the provided logging level.
+ *
+ * If the level is higher than the configured minimal level, returns it,
+ * Otherwise returns undefined.
+ *
+ * @param {String} level a logging level
+ * @returns {String|undefined} corresponding bunyan log level
+ * @private
+ */
+Logger.prototype._getSimpleLogLevel = function(level) {
+    var levelMatch = this._levelMatcher.exec(level);
+    if (levelMatch) {
+        return levelMatch[1];
+    }
+    return undefined;
+};
+
 Logger.prototype.child = function(args) {
     var newArgs = extend({}, this.args, args);
     return new Logger(this, newArgs);
@@ -168,34 +229,45 @@ Logger.prototype._createMessage = function(info) {
     return 'Message not supplied';
 };
 
+
+Logger.prototype._log = function(info, level, logger) {
+    if (info instanceof String) {
+        // Need to convert to primitive
+        info = info.toString();
+    }
+
+    if (typeof info === 'string') {
+        logger[level].call(logger, info);
+    } else if (typeof info === 'object') {
+        // Got an object.
+        //
+        // We don't want to use bunyan's default error handling, as that
+        // drops most attributes on the floor. Instead, make sure we have
+        // a msg, and pass that separately to bunyan.
+        var msg = this._createMessage(info);
+
+        // Inject the detailed levelpath.
+        // 'level' is already used for the numeric level.
+        info.levelPath = level;
+
+        // Also pass in default parameters
+        info = extend(info, this.args);
+        logger[level].call(logger, info, msg);
+    }
+};
+
 Logger.prototype.log = function(level, info) {
-    var levelMatch = this._levelMatcher.exec(level);
-    if (info && levelMatch) {
-        var logger = this._logger;
-        var simpleLevel = levelMatch[1];
+    if (!info) {
+        return;
+    }
 
-        if (info instanceof String) {
-            // Need to convert to primitive
-            info = info.toString();
-        }
-
-        if (typeof info === 'string') {
-            logger[simpleLevel].call(logger, info);
-        } else if (typeof info === 'object') {
-            // Got an object.
-            //
-            // We don't want to use bunyan's default error handling, as that
-            // drops most attributes on the floor. Instead, make sure we have
-            // a msg, and pass that separately to bunyan.
-            var msg = this._createMessage(info);
-
-            // Inject the detailed levelpath.
-            // 'level' is already used for the numeric level.
-            info.levelPath = level;
-
-            // Also pass in default parameters
-            info = extend(info, this.args);
-            logger[simpleLevel].call(logger, info, msg);
+    var simpleLevel = this._getSimpleLogLevel(level);
+    if (simpleLevel) {
+        this._log(info, simpleLevel, this._logger);
+    } else {
+        var componentLoggerConf = this._getComponentLogConfig(level);
+        if (componentLoggerConf) {
+            this._log(info, componentLoggerConf.level, componentLoggerConf.logger);
         }
     }
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -26,6 +26,8 @@ function Logger(confOrLogger, args) {
         // a child logger that accepts everything regardless of the level
         self._componentLoggers = {};
         Object.keys(self._log_components).forEach(function(component) {
+            self._log_components[component] =
+                Math.ceil(self._log_components[component] * 1024);
             self._componentLoggers[component] = self._logger.child({
                 component: component,
                 level: bunyan.TRACE
@@ -182,7 +184,7 @@ Logger.prototype._getComponentLogConfig = function(level) {
         if (slashIndex > 0) {
             var component = level.substr(slashIndex + 1);
             var logProbability = this._log_components[component];
-            if (logProbability && (Math.random() < logProbability)) {
+            if (logProbability && Math.ceil(Math.random() * 1024) < logProbability) {
                 return {
                     level: level.substring(0, slashIndex),
                     logger: this._componentLoggers[component]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
To support sample logging of 'interesting' requests, we can now specify a map of event names (or components) with the probability for them to be logged disregards the target logging level. We can't use a default bunyan logger for that purpose, so we create a special child logger for each of the components and use it.

Ticket: https://phabricator.wikimedia.org/T121163