### PR TITLE
Logging: Improved unhandled rejection logging

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -94,6 +94,22 @@ Logger.prototype._processConf = function(conf) {
         conf.streams = streams;
         conf.level = LEVELS[minLevelIdx];
     }
+
+    // Define custom log message serializers
+    conf.serializers = {
+        err: function(err) {
+            var bunyanSerializedError = bunyan.stdSerializers.err(err);
+            // We don't want to override properties set by bunyan,
+            // as they are fine, we just want to add missing properties
+            Object.keys(err).forEach(function(errKey) {
+                if (bunyanSerializedError[errKey] === undefined) {
+                    bunyanSerializedError[errKey] = err[errKey];
+                }
+            });
+            return bunyanSerializedError;
+        }
+    };
+
     return conf;
 };
 
@@ -115,7 +131,7 @@ Logger.prototype._setupRootHandlers = function() {
     }
 
     // Catch unhandled rejections & log them. This relies on bluebird.
-    P.onPossiblyUnhandledRejection(logUnhandledException);
+    process.on("unhandledRejection", logUnhandledException);
 
     // Similarly, log uncaught exceptions. Also, exit.
     process.on('uncaughtException', function(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
A number of issue were identified in logging code due to the [mysterious EMERGENCY log messages](https://phabricator.wikimedia.org/T121296).
- Starting from bluebird 2.7.0 the recommended way to detect unhandled rejections is to [set up a global handler](http://bluebirdjs.com/docs/api/error-management-configuration.html#global-rejection-events). There's a recommendation [here](http://bluebirdjs.com/docs/api/promise.onpossiblyunhandledrejection.html)
- Bunyan processing for `Error` objects is quite different from normal objects. Although it's nice as it pretty-prints the stack and has other features, it drops all the additional fields we set in our errors. That's fixed with a custom extension for the error serialiser.

There ill be a follow up in RESTBase to avoid unhandled exceptions completely.