### PR TITLE
Worker status logging on worker death

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ options.metrics.histogram('my_histogram', 42, ['foo', 'bar']);
 All metrics are automatically prefixed by the config-provided service name /
 graphite hierachy prefix to ensure a consistent graphite metric hierarchy.
 
+# Worker status tracking
+At any point of the execution the service can emit a `service_status` message
+to update the worker status. Statuses are tracked and reported when the worker
+dies or is killed on a timeout, which is useful for debugging failure reasons.
+
+To emit a status update use the following code:
+```javascript
+process.emit('service_status', {
+   type: 'request_processing_begin',
+   uri: req.uri.toString(),
+   some_other_property: 'some_value'
+})
+```
+
+Note: The status message could be an arbitrary object, however it must not contain
+cyclic references.
+
 ## Issue tracking
 Please report issues in [the service-runner phabricator
 project](https://phabricator.wikimedia.org/tag/service-runner/).

--- a/lib/master.js
+++ b/lib/master.js
@@ -22,7 +22,7 @@ function Master(options) {
     this._shuttingDown = false;
     // Are we performing a rolling restart?
     this._inRollingRestart = false;
-    this.workerHeartbeatTime = {};
+    this.workerStatusMap = {};
 }
 
 util.inherits(Master, BaseService);
@@ -46,9 +46,15 @@ Master.prototype._run = function() {
     cluster.on('exit', function(worker, code, signal) {
         if (!self._shuttingDown && !self._inRollingRestart) {
             var exitCode = worker.process.exitCode;
-            self._logger.log('error/service-runner/master',
-                'worker ' + worker.process.pid + ' died (' + exitCode + '), restarting.');
-            delete self.workerHeartbeatTime[worker.process.pid];
+            var info = {
+                message: 'worker ' + worker.process.pid + ' died (' + exitCode + '), restarting.'
+            };
+            if (self.workerStatusMap[worker.process.pid]
+                    && self.workerStatusMap[worker.process.pid].status) {
+                info.status = self.workerStatusMap[worker.process.pid].status;
+            }
+            self._logger.log('error/service-runner/master', info);
+            delete self.workerStatusMap[worker.process.pid];
             P.delay(Math.random() * 2000).then(function() { self._startWorkers(1); });
         }
     });
@@ -106,7 +112,7 @@ Master.prototype._rollingRestart = function() {
 Master.prototype._stopWorker = function(workerId) {
     var self = this;
     var worker = cluster.workers[workerId];
-    self.workerHeartbeatTime[worker.process.pid] = {
+    self.workerStatusMap[worker.process.pid] = {
         time: null,
         killed: true
     };
@@ -116,13 +122,13 @@ Master.prototype._stopWorker = function(workerId) {
             // worker closes all connections with master. If after a minute
             // it didn't happen, don't expect it happen ever.
             process.kill(worker.process.pid, 'SIGKILL');
-            delete self.workerHeartbeatTime[worker.process.pid];
+            delete self.workerStatusMap[worker.process.pid];
             resolve();
         }, 60000);
         worker.on('disconnect', function() {
             worker.kill('SIGKILL');
             clearTimeout(timeout);
-            delete self.workerHeartbeatTime[worker.process.pid];
+            delete self.workerStatusMap[worker.process.pid];
             resolve();
         });
     });
@@ -158,6 +164,13 @@ function fixCloseDisconnectListeners(worker) {
     });
 }
 
+Master.prototype._onStatusReceived = function(worker, status) {
+    var self = this;
+    var val = self.workerStatusMap[worker.process.pid] || {};
+    val.status = status;
+    self.workerStatusMap[worker.process.pid] = val;
+};
+
 // Fork off one worker at a time, once the previous worker has finished
 // startup.
 Master.prototype._startWorkers = function(remainingWorkers) {
@@ -172,10 +185,19 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                 body: yaml.dump(self.config)
             });
             worker.on('message', function(msg) {
-                if (msg.type === 'startup_finished') {
-                    resolve(self._startWorkers(--remainingWorkers));
-                } else if (msg.type === 'heartbeat') {
-                    self._saveBeat(worker);
+                switch (msg.type) {
+                    case 'startup_finished':
+                        resolve(self._startWorkers(--remainingWorkers));
+                        break;
+                    case 'heartbeat':
+                        self._saveBeat(worker);
+                        break;
+                    case 'service_status':
+                        self._onStatusReceived(worker, msg.status);
+                        break;
+                    default:
+                        self._logger.log('error/service-runner/master',
+                            'unknown message type received from worker ' + msg.type);
                 }
             });
         });
@@ -194,11 +216,17 @@ Master.prototype._checkHeartbeat = function() {
             var now = new Date();
             Object.keys(cluster.workers).forEach(function(workerId) {
                 var worker = cluster.workers[workerId];
-                var lastBeat = self.workerHeartbeatTime[worker.process.pid];
+                var lastBeat = self.workerStatusMap[worker.process.pid];
                 if (!lastBeat || (!lastBeat.killed && now - lastBeat.time
                         > self.config.worker_heartbeat_timeout)) {
-                    self._logger.log('error/service-runner/master',
-                        'worker ' + worker.process.pid + ' stopped sending heartbeats, killing.');
+                    var info = {
+                        message: 'worker ' + worker.process.pid
+                            + ' stopped sending heartbeats, killing.'
+                    };
+                    if (lastBeat.status) {
+                        info.status = lastBeat.status;
+                    }
+                    self._logger.log('error/service-runner/master', info);
                     self._stopWorker(workerId);
                     // Don't need to respawn a worker, it will be restarted upon 'exit' event
                 }
@@ -213,14 +241,13 @@ Master.prototype._checkHeartbeat = function() {
  */
 Master.prototype._saveBeat = function(worker) {
     var self = this;
-    var currentVal = self.workerHeartbeatTime[worker.process.pid];
+    var currentVal = self.workerStatusMap[worker.process.pid];
     if (currentVal && currentVal.killed) {
         return;
     }
-    self.workerHeartbeatTime[worker.process.pid] = {
-        time: new Date(),
-        killed: false
-    };
+    self.workerStatusMap[worker.process.pid] = currentVal || {};
+    self.workerStatusMap[worker.process.pid].time = new Date();
+    self.workerStatusMap[worker.process.pid].killed = false;
 };
 
 module.exports = Master;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -39,6 +39,23 @@ Worker.prototype._getConfigUpdateAction = function() {
                 reject(new Error('Invalid message received: ' + JSON.stringify(message)));
             }
         });
+
+        if (cluster.isWorker) {
+            // If got a status update in a worker - forward it to the master
+            process.on('service_status', function(message) {
+                try {
+                    process.send({
+                        type: 'service_status',
+                        status: message
+                    });
+                } catch (e) {
+                    self._logger.log('warn/service-runner/worker/', {
+                        msg: 'Error sending worker status update',
+                        err: e
+                    });
+                }
+            });
+        }
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
It's generally useful to be able to log a worker death reason together with the death notification message. In particular, this is one of the missing nits that we need to be able to move parsoid to service-runner. 

This patch adds a capability for a service to emit `service_status` messages, that would be tracked, and on worker death the last one would be logged as possible reason of the death. It's possible to enhance that, by, for example, tracking which of the services sent which message, or by reporting N last statuses, but for now the initial implementation should be fine I suppose.