### PR TITLE
Batch requests to metrics

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -47,7 +47,8 @@ function makeStatsD(options, logger) {
         txstatsd: options.type === 'txstatsd',
         globalize: false,
         cacheDns: true,
-        mock: false
+        mock: false,
+        batch: options.batch
     };
     if (options.type === 'txstatsd') {
         statsd = new TXStatsD(statsdOptions);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -33,7 +33,7 @@
     "extend": "^3.0.0",
     "gelf-stream": "^1.0.3",
     "js-yaml": "^3.4.2",
-    "node-statsd": "^0.1.1",
+    "node-statsd": "git+https://github.com/Pchelolo/node-statsd.git#batching",
     "node-txstatsd": "^0.1.6",
     "yargs": "^3.24.0",
     "bunyan-syslog-udp": "^0.1.0"


### PR DESCRIPTION
`statsd` supports batching, but the `node-statsd` client we use doesn't support that, so I've made a PR to support batch mode in the client. I'm going to post the PR upstream, but that repo repo didn't have many attention, so we could use a custom fork for now.

Here is the PR with `node-statsd` patch required for this to work: https://github.com/Pchelolo/node-statsd/pull/1 (it's not a PR to upstream, just across my own branches. Created to simplify the review of the changes). 

I've tested this making a full wikipedia-like stats setup (with a proxy), running restbase benchmarks and tests in both batching and non-batching modes and comparing the results. Everything looks fine.