### PR TITLE
Logging: Improved message if no message was provided

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -155,6 +155,19 @@ Logger.prototype.child = function(args) {
     return new Logger(this, newArgs);
 };
 
+Logger.prototype._createMessage = function(info) {
+    var msg = info.msg || info.message || info.info;
+    if (msg) {
+        return msg;
+    }
+    var infoStr = info.toString();
+    // Check if we've got some relevant result
+    if (infoStr !== '[object Object]') {
+        return infoStr;
+    }
+    return 'Message not supplied';
+};
+
 Logger.prototype.log = function(level, info) {
     var levelMatch = this._levelMatcher.exec(level);
     if (info && levelMatch) {
@@ -169,13 +182,12 @@ Logger.prototype.log = function(level, info) {
         if (typeof info === 'string') {
             logger[simpleLevel].call(logger, info);
         } else if (typeof info === 'object') {
-            var msg;
             // Got an object.
             //
             // We don't want to use bunyan's default error handling, as that
             // drops most attributes on the floor. Instead, make sure we have
             // a msg, and pass that separately to bunyan.
-            msg = info.msg || info.message || info.info || '' + info;
+            var msg = this._createMessage(info);
 
             // Inject the detailed levelpath.
             // 'level' is already used for the numeric level.


### PR DESCRIPTION
Before the patch the logging message for logged objects would be `[object Object]`, which is not very nice. Now we set a message to `Message not supplied` which's cleaner.