### PR TITLE
Metrics: Support metrics batching using the hot-shots client

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,12 @@ logging:
 
 # Statsd metrics reporter
 metrics:
-  type: txstatsd
+  type: statsd
   host: localhost
   port: 8125
+  batch: # Metrics batching options. Supported only for `statsd` reporter type
+    max_size: 1500 # Max size of the batch buffer (default: 1500)
+    max_delay: 1000  # Max delay for an individual metric in milliseconds (default: 1000)
 
 services:
   - name: parsoid

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,6 +1,6 @@
 'use strict';
 var TXStatsD = require('node-txstatsd');
-var StatsD = require('node-statsd');
+var StatsD = require('hot-shots');
 
 var nameCache = {};
 function normalizeName(name) {
@@ -47,9 +47,17 @@ function makeStatsD(options, logger) {
         txstatsd: options.type === 'txstatsd',
         globalize: false,
         cacheDns: true,
-        mock: false,
-        batch: options.batch
+        mock: false
     };
+
+    if (options.batch) {
+        if (typeof options.batch === 'boolean') {
+            options.batch = { max_size: 1500, max_delay: 1000 };
+        }
+        statsdOptions.maxBufferSize = options.batch.max_size || 1500;
+        statsdOptions.bufferFlushInterval = options.batch.max_delay || 1000;
+    }
+
     if (options.type === 'txstatsd') {
         statsd = new TXStatsD(statsdOptions);
     } else if (options.type === 'log') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "core-js": "^1.1.4",
     "extend": "^3.0.0",
     "gelf-stream": "^1.0.3",
+    "hot-shots": "^2.2.0",
     "js-yaml": "^3.4.2",
-    "node-statsd": "git+https://github.com/Pchelolo/node-statsd.git#batching",
     "node-txstatsd": "^0.1.6",
     "yargs": "^3.24.0",
     "bunyan-syslog-udp": "^0.1.0"


### PR DESCRIPTION
Switch from `node-statsd` client, which doesn't support batching and is not maintained to [hot-shots](https://www.npmjs.com/package/hot-shots) client, which is fork that supports batching and seem to be actively developed. 

Also, exposed public batching options interface.

cc @wikimedia/services 