### PR TITLE
Logging: Fix issues with log_components feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,11 @@ worker_heartbeat_timeout: 7500
 logging:
   level: info
   # Sets up sample logging for some 'interesting' events.
-  # Map keys correspond to the event names, specified in the log levels
-  # For example, in 'info/webrequest', the event name is 'webrequest'.
+  # Map keys correspond to the full log level names. 
   # Map values specify the probability for such events to be logged
   # regardless of the configured logging level.
   log_components:
-    webrequest: 0.2
+    'trace/webrequest': 0.2
   streams:
   # Use gelf-stream -> logstash
   - type: gelf

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,13 +21,12 @@ function Logger(confOrLogger, args) {
         delete conf.log_components;
         self._logger = bunyan.createLogger(conf);
         self._levelMatcher = this._levelToMatcher(conf.level);
+        self._allLevelsMatcher = this._levelToMatcher('trace');
 
         // For each specially logged component we need to create
         // a child logger that accepts everything regardless of the level
         self._componentLoggers = {};
         Object.keys(self._log_components).forEach(function(component) {
-            self._log_components[component] =
-                Math.ceil(self._log_components[component] * 1024);
             self._componentLoggers[component] = self._logger.child({
                 component: component,
                 level: bunyan.TRACE
@@ -40,6 +39,7 @@ function Logger(confOrLogger, args) {
         self._log_components = confOrLogger._log_components;
         self._logger = confOrLogger._logger;
         self._levelMatcher = confOrLogger._levelMatcher;
+        self._allLevelsMatcher = confOrLogger._allLevelsMatcher;
         self._componentLoggers = confOrLogger._componentLoggers;
     }
     this.args = args;
@@ -139,6 +139,7 @@ Logger.prototype._setupRootHandlers = function() {
     var self = this;
     // Avoid recursion if there are bugs in the logging code.
     var inLogger = false;
+
     function logUnhandledException(err) {
         if (!inLogger) {
             inLogger = true;
@@ -174,22 +175,19 @@ Logger.prototype._levelToMatcher = function _levelToMatcher(level) {
  * If the message should be logged, returns an object with bunyan log level
  * and a specialized logger for the given component, otherwise returns undefined
  *
- * @param {String} level a logging level
+ * @param {String} levelPath a logging level + component ( e.g. 'warn/component_name' )
  * @returns {Object|undefined} corresponding bunyan log level and a specialized logger
  * @private
  */
-Logger.prototype._getComponentLogConfig = function(level) {
-    if (level && Object.keys(this._log_components).length) {
-        var slashIndex = level.indexOf('/');
-        if (slashIndex > 0) {
-            var component = level.substr(slashIndex + 1);
-            var logProbability = this._log_components[component];
-            if (logProbability && Math.ceil(Math.random() * 1024) < logProbability) {
-                return {
-                    level: level.substring(0, slashIndex),
-                    logger: this._componentLoggers[component]
-                };
-            }
+Logger.prototype._getComponentLogConfig = function(levelPath) {
+    var logProbability = this._log_components[levelPath];
+    if (logProbability && Math.random() < logProbability) {
+        var levelMatch = this._allLevelsMatcher.exec(levelPath);
+        if (levelMatch) {
+            return {
+                level: levelMatch[1],
+                logger: this._componentLoggers[levelPath]
+            };
         }
     }
     return undefined;
@@ -232,14 +230,14 @@ Logger.prototype._createMessage = function(info) {
 };
 
 
-Logger.prototype._log = function(info, level, logger) {
+Logger.prototype._log = function(info, level, levelPath, logger) {
     if (info instanceof String) {
         // Need to convert to primitive
         info = info.toString();
     }
 
     if (typeof info === 'string') {
-        logger[level].call(logger, info);
+        logger[level].call(logger, extend({ msg: info }, this.args));
     } else if (typeof info === 'object') {
         // Got an object.
         //
@@ -250,7 +248,7 @@ Logger.prototype._log = function(info, level, logger) {
 
         // Inject the detailed levelpath.
         // 'level' is already used for the numeric level.
-        info.levelPath = level;
+        info.levelPath = levelPath;
 
         // Also pass in default parameters
         info = extend(info, this.args);
@@ -259,17 +257,17 @@ Logger.prototype._log = function(info, level, logger) {
 };
 
 Logger.prototype.log = function(level, info) {
-    if (!info) {
+    if (!level || !info) {
         return;
     }
 
     var simpleLevel = this._getSimpleLogLevel(level);
     if (simpleLevel) {
-        this._log(info, simpleLevel, this._logger);
+        this._log(info, simpleLevel, level, this._logger);
     } else {
         var componentLoggerConf = this._getComponentLogConfig(level);
         if (componentLoggerConf) {
-            this._log(info, componentLoggerConf.level, componentLoggerConf.logger);
+            this._log(info, componentLoggerConf.level, level, componentLoggerConf.logger);
         }
     }
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -21,7 +21,6 @@ function Logger(confOrLogger, args) {
         delete conf.log_components;
         self._logger = bunyan.createLogger(conf);
         self._levelMatcher = this._levelToMatcher(conf.level);
-        self._allLevelsMatcher = this._levelToMatcher('trace');
 
         // For each specially logged component we need to create
         // a child logger that accepts everything regardless of the level
@@ -39,7 +38,6 @@ function Logger(confOrLogger, args) {
         self._log_components = confOrLogger._log_components;
         self._logger = confOrLogger._logger;
         self._levelMatcher = confOrLogger._levelMatcher;
-        self._allLevelsMatcher = confOrLogger._allLevelsMatcher;
         self._componentLoggers = confOrLogger._componentLoggers;
     }
     this.args = args;
@@ -182,10 +180,10 @@ Logger.prototype._levelToMatcher = function _levelToMatcher(level) {
 Logger.prototype._getComponentLogConfig = function(levelPath) {
     var logProbability = this._log_components[levelPath];
     if (logProbability && Math.random() < logProbability) {
-        var levelMatch = this._allLevelsMatcher.exec(levelPath);
-        if (levelMatch) {
+        var simpleLevel = typeof levelPath === 'string' && levelPath.split('/')[0];
+        if (simpleLevel) {
             return {
-                level: levelMatch[1],
+                level: simpleLevel,
                 logger: this._componentLoggers[levelPath]
             };
         }


### PR DESCRIPTION
There were some issues with https://github.com/wikimedia/service-runner/pull/68 , so making a follow up.
Issues fixed:
- Full levelPath is logged now
- Don't do the integer math on probabilities as it doesn't seem to be needed
- Fixed the code which makes the decision whether to log or not - more robust now.

Also, I've noticed a problem, that when the logged message is a string, default logger args are not logged to it - also fixed.

cc @wikimedia/services 