### PR TITLE
Add the ability to create prefixed child metric clients

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -37,7 +37,7 @@ function LogStatsD(logger, serviceName) {
 // Minimal StatsD wrapper
 function makeStatsD(options, logger) {
     var statsd;
-    var srvName = normalizeName(options.name);
+    var srvName = options._prefix ? options._prefix : normalizeName(options.name);
     var statsdOptions = {
         host: options.host,
         port: options.port,
@@ -61,6 +61,15 @@ function makeStatsD(options, logger) {
     } else {
         statsd = new StatsD(statsdOptions);
     }
+
+    // Support creating sub-metric clients with a fixed prefix. This is useful
+    // for systematically categorizing metrics per-request, by using a
+    // specific logger.
+    statsd.makeChild = function(name) {
+        var childOptions = Object.assign({}, options);
+        childOptions._prefix = statsdOptions.prefix + normalizeName(name) + '.';
+        return makeStatsD(childOptions, logger);
+    };
 
     // Add a static utility method for stat name normalization
     statsd.normalizeName = normalizeName;

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -67,7 +67,7 @@ function makeStatsD(options, logger) {
     // specific logger.
     statsd.makeChild = function(name) {
         var childOptions = Object.assign({}, options);
-        childOptions._prefix = statsdOptions.prefix + normalizeName(name) + '.';
+        childOptions._prefix = statsdOptions.prefix + normalizeName(name);
         return makeStatsD(childOptions, logger);
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "0.3.9",
+  "version": "1.0.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
We would like to be able to prefix all metrics emitted as part of a request
with a fixed prefix, so that we can distinguish internal / external or update
requests & all sub-requests associated with it.

Similar to the logger instance, this patch adds a `makeChild` method on
returned metric clients, which given a name will create such a prefixed metric
client.