### PR TITLE
Metrics: Decreased the default maximum batch size

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -1,6 +1,14 @@
 'use strict';
 var StatsD = require('hot-shots');
 
+/**
+ * Maximum size of a metrics batch used by default.
+ *
+ * @const
+ * @type {number}
+ */
+var DEFAULT_MAX_BATCH_SIZE = 1450;
+
 var nameCache = {};
 function normalizeName(name) {
     // See https://github.com/etsy/statsd/issues/110
@@ -50,9 +58,9 @@ function makeStatsD(options, logger) {
 
     if (options.batch) {
         if (typeof options.batch === 'boolean') {
-            options.batch = { max_size: 1500, max_delay: 1000 };
+            options.batch = { max_size: DEFAULT_MAX_BATCH_SIZE, max_delay: 1000 };
         }
-        statsdOptions.maxBufferSize = options.batch.max_size || 1500;
+        statsdOptions.maxBufferSize = options.batch.max_size || DEFAULT_MAX_BATCH_SIZE;
         statsdOptions.bufferFlushInterval = options.batch.max_delay || 1000;
     }
 


### PR DESCRIPTION
We need to decrease the default maximum batch size to account for IP and UDP headers, so that packets don't exceed MTU. In case of IPv6 it's 48 bytes, so 1450 looks safe enough (we even have 2 bytes 'reserved').