### PR TITLE
Module loading: Support relative paths without a leading dot

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -270,4 +270,19 @@ BaseService.prototype._updateConfig = function _updateConfig(conf) {
     });
 };
 
+BaseService.prototype._requireModule = function(modName) {
+    var self = this;
+    try {
+        return P.resolve(require(modName));
+    } catch (e) {
+        if (!/^\//.test(modName)) {
+            // This might be a relative path, convert it to absolute and try again
+            return self._requireModule(path.resolve(self._basePath + '/' + modName));
+        } else {
+            e.moduleName = modName;
+            return P.reject(e);
+        }
+    }
+};
+
 module.exports = BaseService;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -103,19 +103,6 @@ Worker.prototype._run = function() {
 
     // Require service modules and start them
     return P.all(this.config.services.map(function(service) {
-        var modName = service.module || service.name;
-        if (/^\./.test(modName)) {
-            // resolve relative paths
-            modName = path.resolve(self._basePath + '/' + modName);
-        }
-        var svcMod;
-        try {
-            svcMod = require(modName);
-        } catch (e) {
-            e.moduleName = modName;
-            return P.reject(e);
-        }
-
         var opts = {
             appBasePath: self._basePath,
             config: service.conf,
@@ -126,7 +113,8 @@ Worker.prototype._run = function() {
             metrics: self._metrics
         };
 
-        return P.try(function() {
+        return self._requireModule(service.module || service.name)
+        .then(function(svcMod) {
             if (service.entrypoint) {
                 return svcMod[service.entrypoint](opts);
             } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Currently when loading modules we detect relative paths by the leading dot. However, in other places we support relative paths with no leading dot, so I've updated the module loading code to have the same semantics as we have elsewhere. 

1. If there's a leading `/` - it's an absolute path - require.
2. Otherwise - try to require it as a module, if failed - treat it as a relative path.

cc @wikimedia/services 