### PR TITLE
Bind _stopWorker to self to avoid crash on master shutdown

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -65,7 +65,7 @@ Master.prototype._run = function() {
         if (self.interval) {
             clearInterval(self.interval);
         }
-        P.map(Object.keys(cluster.workers), self._stopWorker)
+        P.map(Object.keys(cluster.workers), self._stopWorker.bind(self))
         .then(function() {
             self._logger.log('info/service-runner/master', 'Exiting master');
             process.exit(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
We didn't bind `_stopWorker` to self, so `this` was undefined which led to master crash on shutdown

cc @wikimedia/services 