### PR TITLE
Fix service module loading and release v1.1.4

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -272,15 +272,27 @@ BaseService.prototype._updateConfig = function _updateConfig(conf) {
 
 BaseService.prototype._requireModule = function(modName) {
     var self = this;
+    var opts = arguments[1] || { mod: modName, baseTried: false, modsTried: false };
     try {
         return P.resolve(require(modName));
     } catch (e) {
-        if (!/^\//.test(modName)) {
-            // This might be a relative path, convert it to absolute and try again
-            return self._requireModule(path.resolve(self._basePath + '/' + modName));
-        } else {
-            e.moduleName = modName;
+        if (/^\//.test(opts.mod) || (opts.baseTried && opts.modsTried)) {
+            // we have a full path here which can't be required, or we tried
+            // all of the possible combinations, so bail out
+            e.moduleName = opts.mod;
             return P.reject(e);
+        } else {
+            // This might be a relative path, convert it to absolute and try again
+            if (!opts.baseTried) {
+                // first, try to load it from the app's base path
+                opts.baseTried = true;
+                modName = path.join(self._basePath, opts.mod);
+            } else {
+                // then, retry its node_modules directory
+                opts.modsTried = true;
+                modName = path.join(self._basePath, 'node_modules', opts.mod);
+            }
+            return self._requireModule(modName, opts);
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
One can specify an npm module name to load for a service's start-up process. Node then tries to find it in the usual way - by searching the path up to root for that module and in the global modules' directory. However, node starts the search from service-runner's path, not the service's one. Effectively, the module that service-runner is requiring is its peer dependency. Unfortunately, this doesn't work in cases where node modules are symlinked into the relevant node_modules directory. So, when a relative path is encountered and the module fails to load, try to load it both from the application's base path as well as its node_modules sub-directory, if one exists.