### PR TITLE
Docker: Allow users to specify the full submodule remote ref

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -275,10 +275,13 @@ function updateDeploy() {
     // check if there is an alternative repo name defined
     return P.props({
         name: promisedGit(['config', 'deploy.name'], { ignoreErr: true }),
-        remote: promisedGit(['config', 'deploy.remote'], { ignoreErr: true })
+        remote: promisedGit(['config', 'deploy.remote'], { ignoreErr: true }),
+        submodule_ref: promisedGit(['config', 'deploy.submodule'], { ignoreErr: true })
     }).then(function(props) {
-        opts.name = props.name ? props.name : pkg.name;
-        opts.remote_name = props.remote ? props.remote : 'origin';
+        opts.name = props.name || pkg.name;
+        opts.remote_name = props.remote || 'origin';
+        opts.submodule_ref = props.submodule_ref ||
+            'https://gerrit.wikimedia.org/r/mediawiki/services/' + opts.name;
         opts.remote_branch = opts.remote_name + '/master';
         // we need to CHDIR into the deploy dir for subsequent operations
         process.chdir(opts.dir);
@@ -355,7 +358,7 @@ function updateDeploy() {
             opts.commit_msg = 'Initial import of ' + opts.name;
             return promisedGit(['submodule',
                 'add',
-                'https://gerrit.wikimedia.org/r/mediawiki/services/' + opts.name,
+                opts.submodule_ref,
                 opts.submodule]);
         }
     }).then(function() {
@@ -506,7 +509,7 @@ function main(options, configuration) {
 
     // use the package's name as the image name
     imgName = pkg.name;
-    if (opts.deploy) { imgName += 'deploy'; }
+    if (opts.deploy) { imgName += '-deploy'; }
     // the container's name
     name = pkg.name + '-' + Date.now() + '-' + Math.floor(Math.random() * 1000);
 


### PR DESCRIPTION
Up until now, the deploy-repo-build script was fixing the submodule's
remote reference to be gerrit.wm.org/r/mediawiki/services/. However,
this is rather Mediawiki- and Services-team-centric. This commit fixes
that by introducing another configuration directive - deploy.submodule -
which allows users to specify their own sources for the submodule.

Bug: [T126294](https://phabricator.wikimedia.org/T126294)