### PR TITLE
Attach volume for tests

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -211,8 +211,8 @@ function buildImg() {
 /**
  * Starts the container and returns once it has finished executing
  *
- * @param {Array} args the array of extra parameters to pass, optional
- * @param {Boolean} hidePorts whether to keep the ports hidden inside the container, optional
+ * @param {Array} [args] the array of extra parameters to pass, optional
+ * @param {Boolean} [hidePorts] whether to keep the ports hidden inside the container, optional
  * @return {Promise} the promise starting the container
  */
 function startContainer(args, hidePorts) {
@@ -527,6 +527,9 @@ function main(options, configuration) {
     .then(function() {
         if (opts.deploy) {
             return updateDeploy();
+        } else if (opts.tests) {
+            // append a volume so that tests could create files in container
+            return startContainer(['-v', process.cwd() + ':/opt/service']);
         } else {
             return startContainer();
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
When using `docker-test` command, some services could have a need to create files in the service dir. An example is `restbase` which is tested in SQLite mode in docker and so needs to create a db file. Without attaching the volume it fails to do so, so the tests are failing.

cc @wikimedia/services 