### PR TITLE
Enable metrics batching by default

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -56,10 +56,9 @@ function makeStatsD(options, logger) {
         mock: false
     };
 
-    if (options.batch) {
-        if (typeof options.batch === 'boolean') {
-            options.batch = { max_size: DEFAULT_MAX_BATCH_SIZE, max_delay: 1000 };
-        }
+    // Batch metrics unless `batch` option is `false`
+    if (typeof options.batch !== 'boolean' || options.batch) {
+        options.batch = options.batch || {};
         statsdOptions.maxBufferSize = options.batch.max_size || DEFAULT_MAX_BATCH_SIZE;
         statsdOptions.bufferFlushInterval = options.batch.max_delay || 1000;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Metrics batching was enabled for restbase for a long period of time - enable it by default for other services.

cc @wikimedia/services 