### PR TITLE
Handle worker deaths on startup properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,6 @@ services, which will set up this & other things for you.
 # Set to 0 to run everything in a single process without clustering.
 num_workers: 1
 
-# Timeout for worker startup in milliseconds. Default is 60000.
-startup_timeout: 10000
-
 # Number of milliseconds to wait for a heartbeat from worker before killing
 # and restarting it
 worker_heartbeat_timeout: 7500

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ services, which will set up this & other things for you.
 # Set to 0 to run everything in a single process without clustering.
 num_workers: 1
 
+# Timeout for worker startup in milliseconds. Default is 60000.
+startup_timeout: 10000
+
 # Number of milliseconds to wait for a heartbeat from worker before killing
 # and restarting it
 worker_heartbeat_timeout: 7500

--- a/lib/master.js
+++ b/lib/master.js
@@ -24,8 +24,7 @@ function Master(options) {
     this._shuttingDown = false;
     // Are we performing a rolling restart?
     this._inRollingRestart = false;
-    this._firstWorkerStarted = false;
-    this._firstWorkerStartupAttempts = 0;
+    this._currentStartingWorker = undefined;
     this.workerStatusMap = {};
 }
 
@@ -48,7 +47,9 @@ Master.prototype._run = function() {
         + this.config.num_workers + ' workers');
 
     cluster.on('exit', function(worker) {
-        if (!self._shuttingDown && !self._inRollingRestart) {
+        if (!self._shuttingDown
+                && !self._inRollingRestart
+                && self._currentStartingWorker !== worker.process.pid) {
             var exitCode = worker.process.exitCode;
             var info = {
                 message: 'worker ' + worker.process.pid + ' died (' + exitCode + '), restarting.'
@@ -188,6 +189,7 @@ Master.prototype._startWorkers = function(remainingWorkers) {
     var self = this;
     if (remainingWorkers) {
         var worker = cluster.fork();
+        self._currentStartingWorker = worker.process.pid;
         self._saveBeat(worker);
         return new P(function(resolve) {
             fixCloseDisconnectListeners(worker);
@@ -197,25 +199,13 @@ Master.prototype._startWorkers = function(remainingWorkers) {
             });
 
             var workerExit = function(code) {
-                if (self._firstWorkerStarted) {
-                    self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
-                        + ' died during startup (' + code + '), continue startup');
-                    // This worker will be restarted by generic restart logic
-                    resolve(self._startWorkers(--remainingWorkers));
-                } else if (self._firstWorkerStartupAttempts++ < 3) {
-                    self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
-                        + ' died during startup (' + code
-                        + '), continue startup, attempt ' + self._firstWorkerStartupAttempts);
-                    // This worker will be restarted by generic restart logic
-                    resolve(self._startWorkers(--remainingWorkers));
-                } else {
-                    self._logger.log('fatal/service-runner/master',
-                        'startup failed, exiting master');
-                    // Don't exit right away, allow logger to process message
-                    setTimeout(function() {
-                        process.exit(1);
-                    }, 1000);
-                }
+                self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
+                    + ' died during startup (' + code + '), continue startup');
+                // Let all the exit listeners fire before reassigning current worker ID
+                process.nextTick(function() {
+                    self._currentStartingWorker = undefined;
+                    resolve(self._startWorkers(remainingWorkers));
+                });
             };
 
             worker.on('exit', workerExit);
@@ -223,7 +213,7 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                 switch (msg.type) {
                     case 'startup_finished':
                         worker.removeListener('exit', workerExit);
-                        self._firstWorkerStarted = true;
+                        self._currentStartingWorker = undefined;
                         resolve(self._startWorkers(--remainingWorkers));
                         break;
                     case 'heartbeat':

--- a/lib/master.js
+++ b/lib/master.js
@@ -54,7 +54,7 @@ Master.prototype._run = function() {
                 message: 'worker ' + worker.process.pid + ' died (' + exitCode + '), restarting.'
             };
             if (self.workerStatusMap[worker.process.pid]
-                && self.workerStatusMap[worker.process.pid].status) {
+                    && self.workerStatusMap[worker.process.pid].status) {
                 info.status = self.workerStatusMap[worker.process.pid].status;
             }
             self._logger.log('error/service-runner/master', info);
@@ -90,11 +90,9 @@ Master.prototype._run = function() {
         .then(self._rollingRestart.bind(self));
     });
 
-
     self._ratelimiter = new RateLimiterMaster(self.config.ratelimiter);
-    var setupPromise = self._ratelimiter.setup();
 
-    return setupPromise
+    return self._ratelimiter.setup()
     .then(function() {
         return self._startWorkers(self.config.num_workers);
     })
@@ -201,13 +199,13 @@ Master.prototype._startWorkers = function(remainingWorkers) {
             var workerExit = function(code) {
                 if (self._firstWorkerStarted) {
                     self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
-                        + ' died during startup (' + code + '), continue');
+                        + ' died during startup (' + code + '), continue startup');
                     // This worker will be restarted by generic restart logic
                     resolve(self._startWorkers(--remainingWorkers));
                 } else if (self._firstWorkerStartupAttempts++ < 3) {
                     self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
                         + ' died during startup (' + code
-                        + '), continue attempt ' + self._firstWorkerStartupAttempts);
+                        + '), continue startup, attempt ' + self._firstWorkerStartupAttempts);
                     // This worker will be restarted by generic restart logic
                     resolve(self._startWorkers(--remainingWorkers));
                 } else {

--- a/lib/master.js
+++ b/lib/master.js
@@ -213,6 +213,7 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                 startTimeout = setTimeout(function() {
                     self._logger.log('warn/service-runner/master',
                         'Timeout for worker ' + worker.process.pid + ', respawn');
+                    worker.kill();
                     resolve(self._startWorkers(--remainingWorkers));
                 }, self.startupTimeout);
             } else {

--- a/lib/master.js
+++ b/lib/master.js
@@ -12,6 +12,15 @@ var Logger = require('./logger');
 var RateLimiterMaster = require('./ratelimiter').master;
 
 /**
+ * Default timeout for worker startup.
+ * Can be overwritten with startup_timeout config property.
+ *
+ * @const
+ * @type {number}
+ */
+var DEFAULT_STARTUP_TIMEOUT = 60000;
+
+/**
  * Master class, inherits from BaseService.
  * Contains logic that run in the master process.
  *
@@ -20,10 +29,13 @@ var RateLimiterMaster = require('./ratelimiter').master;
 function Master(options) {
     BaseService.call(this, options);
 
+    this.startupTimeout = options.startup_timeout || DEFAULT_STARTUP_TIMEOUT;
+
     // Is the master shutting down?
     this._shuttingDown = false;
     // Are we performing a rolling restart?
     this._inRollingRestart = false;
+    this._firstWorkerStarted = false;
     this.workerStatusMap = {};
 }
 
@@ -195,9 +207,29 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                 type: 'config',
                 body: yaml.dump(self.config)
             });
+
+            var startTimeout;
+            if (self._firstWorkerStarted) {
+                startTimeout = setTimeout(function() {
+                    self._logger.log('warn/service-runner/master',
+                        'Timeout for worker ' + worker.process.pid + ', respawn');
+                    resolve(self._startWorkers(--remainingWorkers));
+                }, self.startupTimeout);
+            } else {
+                startTimeout = setTimeout(function() {
+                    self._logger.log('fatal/service-runner/master',
+                        'Startup failed, exiting master');
+                    // Don't exit right away, allow logger to process message
+                    setTimeout(function() {
+                        process.exit(1);
+                    }, 1000);
+                }, self.startupTimeout);
+            }
             worker.on('message', function(msg) {
                 switch (msg.type) {
                     case 'startup_finished':
+                        clearTimeout(startTimeout);
+                        self._firstWorkerStarted = true;
                         resolve(self._startWorkers(--remainingWorkers));
                         break;
                     case 'heartbeat':

--- a/lib/master.js
+++ b/lib/master.js
@@ -12,15 +12,6 @@ var Logger = require('./logger');
 var RateLimiterMaster = require('./ratelimiter').master;
 
 /**
- * Default timeout for worker startup.
- * Can be overwritten with startup_timeout config property.
- *
- * @const
- * @type {number}
- */
-var DEFAULT_STARTUP_TIMEOUT = 60000;
-
-/**
  * Master class, inherits from BaseService.
  * Contains logic that run in the master process.
  *
@@ -29,13 +20,12 @@ var DEFAULT_STARTUP_TIMEOUT = 60000;
 function Master(options) {
     BaseService.call(this, options);
 
-    this.startupTimeout = options.startup_timeout || DEFAULT_STARTUP_TIMEOUT;
-
     // Is the master shutting down?
     this._shuttingDown = false;
     // Are we performing a rolling restart?
     this._inRollingRestart = false;
     this._firstWorkerStarted = false;
+    this._firstWorkerStartupAttempts = 0;
     this.workerStatusMap = {};
 }
 
@@ -57,14 +47,14 @@ Master.prototype._run = function() {
     this._logger.log('info/service-runner', 'master(' + process.pid + ') initializing '
         + this.config.num_workers + ' workers');
 
-    cluster.on('exit', function(worker, code, signal) {
+    cluster.on('exit', function(worker) {
         if (!self._shuttingDown && !self._inRollingRestart) {
             var exitCode = worker.process.exitCode;
             var info = {
                 message: 'worker ' + worker.process.pid + ' died (' + exitCode + '), restarting.'
             };
             if (self.workerStatusMap[worker.process.pid]
-                    && self.workerStatusMap[worker.process.pid].status) {
+                && self.workerStatusMap[worker.process.pid].status) {
                 info.status = self.workerStatusMap[worker.process.pid].status;
             }
             self._logger.log('error/service-runner/master', info);
@@ -100,9 +90,9 @@ Master.prototype._run = function() {
         .then(self._rollingRestart.bind(self));
     });
 
-    var setupPromise = P.resolve();
+
     self._ratelimiter = new RateLimiterMaster(self.config.ratelimiter);
-    setupPromise = self._ratelimiter.setup();
+    var setupPromise = self._ratelimiter.setup();
 
     return setupPromise
     .then(function() {
@@ -208,28 +198,33 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                 body: yaml.dump(self.config)
             });
 
-            var startTimeout;
-            if (self._firstWorkerStarted) {
-                startTimeout = setTimeout(function() {
-                    self._logger.log('warn/service-runner/master',
-                        'Timeout for worker ' + worker.process.pid + ', respawn');
-                    worker.kill();
+            var workerExit = function(code) {
+                if (self._firstWorkerStarted) {
+                    self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
+                        + ' died during startup (' + code + '), continue');
+                    // This worker will be restarted by generic restart logic
                     resolve(self._startWorkers(--remainingWorkers));
-                }, self.startupTimeout);
-            } else {
-                startTimeout = setTimeout(function() {
+                } else if (self._firstWorkerStartupAttempts++ < 3) {
+                    self._logger.log('warn/service-runner/master', 'worker ' + worker.process.pid
+                        + ' died during startup (' + code
+                        + '), continue attempt ' + self._firstWorkerStartupAttempts);
+                    // This worker will be restarted by generic restart logic
+                    resolve(self._startWorkers(--remainingWorkers));
+                } else {
                     self._logger.log('fatal/service-runner/master',
-                        'Startup failed, exiting master');
+                        'startup failed, exiting master');
                     // Don't exit right away, allow logger to process message
                     setTimeout(function() {
                         process.exit(1);
                     }, 1000);
-                }, self.startupTimeout);
-            }
+                }
+            };
+
+            worker.on('exit', workerExit);
             worker.on('message', function(msg) {
                 switch (msg.type) {
                     case 'startup_finished':
-                        clearTimeout(startTimeout);
+                        worker.removeListener('exit', workerExit);
                         self._firstWorkerStarted = true;
                         resolve(self._startWorkers(--remainingWorkers));
                         break;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -41,8 +41,8 @@
   },
   "devDependencies": {
     "mocha": "^2.4.5",
-    "mocha-jshint": "^2.3.0",
-    "mocha-jscs": "^4.2.0",
+    "mocha-jshint": "^2.3.1",
+    "mocha-jscs": "^5.0.0",
     "bunyan-prettystream": "git+https://github.com/hadfieldn/node-bunyan-prettystream#master"
   }
 }

--- a/service-runner.js
+++ b/service-runner.js
@@ -36,5 +36,5 @@ module.exports = ServiceRunner;
 
 if (module.parent === null) {
     // Run as a script: Start up
-    return new ServiceRunner().run();
+    new ServiceRunner().run();
 }


### PR DESCRIPTION
In case the worker fails to start, we have to continue startup sequence.

cc @wikimedia/services 

Bug: https://phabricator.wikimedia.org/T135615