### PR TITLE
Clarify run() return value & support service shutdown with stop()

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Example script for **starting** a service, using commandline options:
 
 ```javascript
 var ServiceRunner = require('service-runner');
-new ServiceRunner().run();
+new ServiceRunner().start();
 ```
 It is also possible to skip commandline options, and pass in a config
-directly to `ServiceRunner.run()` (see [the config section](#config_loading)
+directly to `ServiceRunner.start()` (see [the config section](#config_loading)
 for details on available options). Here is an example demonstrating this, as
 well as return values & the `stop()` method:
 
@@ -83,7 +83,7 @@ well as return values & the `stop()` method:
 var ServiceRunner = require('service-runner');
 var runner = new ServiceRunner();
 
-var startupPromise = runner.run({
+var startupPromise = runner.start({
     num_workers: 0,
     services: [{
         name: 'parsoid',

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ module.exports = function (options) {
     // Metrics reporter (statsd,log)
     var metrics = options.metrics;
 
-    // Start the app, returning a promise
+    // Start the app, returning a promise.
+    // Return an object with a `close()` function for clean shut-down support.
+    // (ex: node's HTTP server instances).
     return startApp(config, logger, metrics);
 }
 ```
@@ -48,7 +50,7 @@ Options:
 ```bash
 npm install --save service-runner
 ```
-
+### As a binary
 In package.json, configure `npm start` to call service-runner:
 ```javascript
   "scripts": {
@@ -60,29 +62,53 @@ module parameter to your service's entry point.
 
 Finally, **start your service with `npm start`**. In npm >= 2.0 (node 0.12 or iojs), you can also pass parameters to `service-runner` like this: `npm start -- -c /etc/yourservice/config.yaml`.
 
-For node 0.10 support, you can create a small wrapper script like this:
+### As a library
+
+Service-runner can also be used to run services within an application. This is
+useful for node 0.10 support, but can also be used to run services for testing
+or other purposes.
+
+Example script for **starting** a service, using commandline options:
+
 ```javascript
 var ServiceRunner = require('service-runner');
 new ServiceRunner().run();
 ```
+It is also possible to skip commandline options, and pass in a config
+directly to `ServiceRunner.run()` (see [the config section](#config_loading)
+for details on available options). Here is an example demonstrating this, as
+well as return values & the `stop()` method:
 
-All file paths in the config are relative to the application base path. 
-The base path is an absolute path to the folder where your application 
-is located (where `package.json` file is located).
+```javascript
+var ServiceRunner = require('service-runner');
+var runner = new ServiceRunner();
 
-By default, we assume that your project depends on `service-runner` and 
-you follow standard node project layout. However, if a custom layout is 
-used, you must override the app base path with either:
-- `APP_BASE_PATH` environment variable
-- `app_base_path` config stanza.
-
-We are also working on a [standard
-template](https://github.com/wikimedia/service-template-node) for node
-services, which will set up this & other things for you.
+var startupPromise = runner.run({
+    num_workers: 0,
+    services: [{
+        name: 'parsoid',
+        conf: {...}
+    }],
+    logging: {...},
+})
+.then(function(startupResults) {
+    // startupResults is an array of arrays of objects returned by each
+    // service. These objects should be JSON.stringify()-able.
+})
+.then(function() {
+    // To stop a service, call the stop() method
+    return runner.stop();
+});
+```
 
 ### Config loading
 - Default config locations in a project: `config.yaml` for a customized config,
     and `config.example.yaml` for the defaults.
+ - By default, we assume that your project depends on `service-runner` and 
+   you follow standard node project layout. However, if a custom layout is used,
+   you must override the app base path with either:
+     - `APP_BASE_PATH` environment variable
+     - `app_base_path` config stanza.
 - Default top-level config format (**draft**):
 
 ```yaml
@@ -141,6 +167,14 @@ services:
         interface: localhost
         # more per-service config settings
 ```
+
+All file paths in the config are relative to the application base path. 
+The base path is an absolute path to the folder where your application 
+is located (where `package.json` file is located).
+
+We are also working on a [standard
+template](https://github.com/wikimedia/service-template-node) for node
+services, which will set up this & other things for you.
 
 ### Metric reporting
 

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -15,7 +15,7 @@ var docker = require('./docker');
  * Contains common logic, mostly config and options parsing.
  * Each implementation should override two methods:
  *  - _getConfigUpdateAction - returns a config-updating promise
- *  - _run - runs the service
+ *  - _start - runs the service
  *
  * @constructor
  */
@@ -43,7 +43,7 @@ BaseService.prototype._setAppBasePath = function(config) {
     }
 };
 
-BaseService.prototype.run = function run(conf) {
+BaseService.prototype.start = function start(conf) {
     var self = this;
     return self._getConfigUpdateAction(conf)
     .then(function() {
@@ -62,7 +62,7 @@ BaseService.prototype.run = function run(conf) {
 
         self._logger = new Logger(config.logging);
 
-        return self._run();
+        return self._start();
     });
 };
 

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -28,6 +28,7 @@ function BaseService(options) {
 
     this._logger = null;
     this._metrics = null;
+    this.serviceReturns = null;
 }
 
 BaseService.prototype._setAppBasePath = function(config) {

--- a/lib/master.js
+++ b/lib/master.js
@@ -46,11 +46,26 @@ Master.prototype._getConfigUpdateAction = function(conf) {
     return this._updateConfig(conf);
 };
 
+Master.prototype.stop = function() {
+    var self = this;
+    if (self.config.num_workers === 0) {
+        // No workers needed, run worker code directly.
+        return Worker.prototype.stop.call(self);
+    }
+    self._shuttingDown = true;
+    self._logger.log('info/service-runner/master', 'master shutting down, killing workers');
+    if (self.interval) {
+        clearInterval(self.interval);
+    }
+    return P.map(Object.keys(cluster.workers), self._stopWorker.bind(self));
+};
+
 Master.prototype._run = function() {
     var self = this;
 
     if (self.config.num_workers === 0) {
         // No workers needed, run worker code directly.
+        // FIXME: Create a Master / Worker dynamically on _run()?
         return Worker.prototype._run.call(self);
     }
 
@@ -76,18 +91,13 @@ Master.prototype._run = function() {
         }
     });
 
-    var shutdownMaster = function() {
-        self._shuttingDown = true;
-        self._logger.log('info/service-runner/master', 'master shutting down, killing workers');
-        if (self.interval) {
-            clearInterval(self.interval);
-        }
-        P.map(Object.keys(cluster.workers), self._stopWorker.bind(self))
+    function shutdownMaster() {
+        self.stop()
         .then(function() {
             self._logger.log('info/service-runner/master', 'Exiting master');
             process.exit(0);
         });
-    };
+    }
 
     process.on('SIGINT', shutdownMaster);
     process.on('SIGTERM', shutdownMaster);
@@ -111,9 +121,9 @@ Master.prototype._run = function() {
     .then(function() {
         return self._startWorkers(self.config.num_workers);
     })
-    .then(function(workers) {
+    .then(function(workerReturns) {
         self._checkHeartbeat();
-        return workers;
+        return workerReturns;
     });
 };
 
@@ -199,7 +209,8 @@ Master.prototype._onStatusReceived = function(worker, status) {
 
 // Fork off one worker at a time, once the previous worker has finished
 // startup.
-Master.prototype._startWorkers = function(remainingWorkers) {
+Master.prototype._startWorkers = function(remainingWorkers, res) {
+    res = res || [];
     var self = this;
     if (remainingWorkers) {
         var worker = cluster.fork();
@@ -246,7 +257,8 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                         worker.removeListener('exit', workerExit);
                         self._currentStartingWorker = undefined;
                         self._firstWorkerStarted = true;
-                        resolve(self._startWorkers(--remainingWorkers));
+                        res.push(msg.serviceReturns[0]);
+                        resolve(self._startWorkers(--remainingWorkers, res));
                         break;
                     case 'heartbeat':
                         self._saveBeat(worker);
@@ -263,6 +275,8 @@ Master.prototype._startWorkers = function(remainingWorkers) {
                 }
             });
         });
+    } else {
+        return res;
     }
 };
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -60,13 +60,13 @@ Master.prototype.stop = function() {
     return P.map(Object.keys(cluster.workers), self._stopWorker.bind(self));
 };
 
-Master.prototype._run = function() {
+Master.prototype._start = function() {
     var self = this;
 
     if (self.config.num_workers === 0) {
         // No workers needed, run worker code directly.
-        // FIXME: Create a Master / Worker dynamically on _run()?
-        return Worker.prototype._run.call(self);
+        // FIXME: Create a Master / Worker dynamically on _start()?
+        return Worker.prototype._start.call(self);
     }
 
     // Fork workers.

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -65,16 +65,32 @@ Worker.prototype._getConfigUpdateAction = function() {
     });
 };
 
+Worker.prototype.stop = function() {
+    var self = this;
+    if (self.interval) {
+        clearInterval(self.interval);
+    }
+    if (Array.isArray(self.serviceReturns)) {
+        return P.each(self.serviceReturns, function(serviceRet) {
+            if (serviceRet && typeof serviceRet.close === 'function') {
+                return serviceRet.close();
+            }
+        });
+    } else {
+        return P.resolve();
+    }
+};
+
 Worker.prototype._run = function() {
     var self = this;
     // Worker.
     process.on('SIGTERM', function() {
-        if (self.interval) {
-            clearInterval(self.interval);
-        }
-        self._logger.log('info/service-runner/worker', 'Worker '
-            + process.pid + ' shutting down');
-        process.exit(0);
+        return self.stop()
+        .then(function() {
+            self._logger.log('info/service-runner/worker', 'Worker '
+                    + process.pid + ' shutting down');
+            process.exit(0);
+        });
     });
 
     // Enable heap dumps in /tmp on kill -USR2.
@@ -143,9 +159,15 @@ Worker.prototype._run = function() {
     .then(function(res) {
         // Signal that this worker finished startup
         if (cluster.isWorker) {
-            process.send({ type: 'startup_finished' });
+            process.send({ type: 'startup_finished', serviceReturns: res });
         }
-        return res;
+        self.serviceReturns = res;
+        // Make sure that only JSON-serializable values are returned.
+        try {
+            return [JSON.parse(JSON.stringify(res))];
+        } catch (e) {
+            return [e];
+        }
     })
     .catch(function(e) {
         self._logger.log('fatal/service-runner/worker', e);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -81,7 +81,7 @@ Worker.prototype.stop = function() {
     }
 };
 
-Worker.prototype._run = function() {
+Worker.prototype._start = function() {
     var self = this;
     // Worker.
     process.on('SIGTERM', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -33,6 +33,10 @@ ServiceRunner.prototype.run = function run(conf) {
     return this._impl.run(conf);
 };
 
+ServiceRunner.prototype.stop = function stop() {
+    return this._impl.stop();
+};
+
 
 module.exports = ServiceRunner;
 

--- a/service-runner.js
+++ b/service-runner.js
@@ -29,14 +29,25 @@ function ServiceRunner(options) {
     }
 }
 
-ServiceRunner.prototype.run = function run(conf) {
-    return this._impl.run(conf);
+ServiceRunner.prototype.start = function start(conf) {
+    return this._impl.start(conf);
 };
 
 ServiceRunner.prototype.stop = function stop() {
     return this._impl.stop();
 };
 
+// @deprecated
+ServiceRunner.prototype.run = function run(conf) {
+    var self = this;
+    return this.start(conf)
+    .then(function(res) {
+        // Delay the log call until the logger is actually set up.
+        self._impl._logger.log('warn/service-runner',
+                'ServiceRunner.run() is deprecated, and will be removed in v3.x.');
+        return res;
+    });
+};
 
 module.exports = ServiceRunner;
 


### PR DESCRIPTION
- Consistently return worker startup results, with or without workers
  (`num_workers != 0`). Require results to be JSON.stringify()-able, and
  support returning a `close()` method for each service.
- Add a `stop()` method on ServiceRunner, and close each service in each
  worker (if any) when it is called. This relies on a `close()` method being
  returned from services, which currently is the case for `http.Server`
  instances as returned by hyperswitch and the service-template.

Bug: https://phabricator.wikimedia.org/T135679