### PR TITLE
Bail out of module loading if the error is not about the module

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -276,9 +276,11 @@ BaseService.prototype._requireModule = function(modName) {
     try {
         return P.resolve(require(modName));
     } catch (e) {
-        if (/^\//.test(opts.mod) || (opts.baseTried && opts.modsTried)) {
-            // we have a full path here which can't be required, or we tried
-            // all of the possible combinations, so bail out
+        if (/^\//.test(opts.mod) || (opts.baseTried && opts.modsTried) ||
+                e.message !== "Cannot find module '" + modName + "'") {
+            // we have a full path here which can't be required, we have tried
+            // all of the possible combinations, or the error is not about not
+            // finding modName, so bail out
             e.moduleName = opts.mod;
             return P.reject(e);
         } else {


### PR DESCRIPTION
The `_requireModule()` method tries all possible combinations of a module's path in order to find it and load it. However, up until now we would try to do so regardless of the reason of module failure, which meant that if the module could be found, but there was an error while loading it, we would assume it couldn't be found. This resulted in cryptic error messages of the type "Cannot find module $PWD/node_modules/module.js" even when the module could be found, but failed to load for some other reason. This PR fixes it.