### PR TITLE
Removed core-js dependency

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -128,9 +128,9 @@ BaseService.prototype._getOptions = function(opts) {
     .argv;
 
     args.deployRepo = args.deployRepo || args.review;
-    args.build = args._.includes('build') || args.deployRepo;
-    args.dockerStart = args._.includes('docker-start');
-    args.dockerTest = args._.includes('docker-test');
+    args.build = args._.indexOf('build') !== -1 || args.deployRepo;
+    args.dockerStart = args._.indexOf('docker-start') !== -1;
+    args.dockerTest = args._.indexOf('docker-test') !== -1;
     args.deployRepo = args.deployRepo || args.build;
 
     if (args.build && args.dockerStart || args.build && args.dockerTest

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -9,6 +9,13 @@ var StatsD = require('hot-shots');
  */
 var DEFAULT_MAX_BATCH_SIZE = 1450;
 
+function objectAssign(target, source) {
+    Object.keys(source).forEach(function(keyName) {
+        target[keyName] = source[keyName];
+    });
+    return target;
+}
+
 var nameCache = {};
 function normalizeName(name) {
     // See https://github.com/etsy/statsd/issues/110
@@ -73,7 +80,7 @@ function makeStatsD(options, logger) {
     // for systematically categorizing metrics per-request, by using a
     // specific logger.
     statsd.makeChild = function(name) {
-        var childOptions = Object.assign({}, options);
+        var childOptions = objectAssign({}, options);
         childOptions._prefix = statsdOptions.prefix + normalizeName(name);
         return makeStatsD(childOptions, logger);
     };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "bluebird": "^3.4.0",
     "bunyan": "^1.8.1",
     "bunyan-syslog-udp": "^0.1.0",
-    "core-js": "^2.4.0",
     "extend": "^3.0.0",
     "gelf-stream": "^1.1.0",
     "hot-shots": "^2.3.1",

--- a/service-runner.js
+++ b/service-runner.js
@@ -7,9 +7,6 @@
  */
 'use strict';
 
-// Upgrade to es6
-require('core-js/shim');
-
 var cluster = require('cluster');
 var Master = require('./lib/master');
 var Worker = require('./lib/worker');


### PR DESCRIPTION
In #99 we've been discussing the `core-js` dependency, and got to an agreement that it has to be removed from `service-runner`. This PR removes it, and shims manually all places where functions, not supported in node 0.10 are used. 

It will be a no-op for all `hyperswitch` services, since it load up `core-js` in it's index file. Although, for other services this might be an API-change, so we have to bump the version accordingly. I'm not sure whether to bump it to 2.0.0 or 1.4.0 though..

cc @wikimedia/services 