### PR TITLE
Docker: set the IN_DOCKER env var when in Docker; release v1.3.1

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -177,6 +177,8 @@ function createDockerFile() {
         contents += 'ENV HOME=/root/ LINK=g++\n';
     }
 
+    contents += 'ENV IN_DOCKER=1\n';
+
     if (opts.deploy) {
         contents += 'CMD ' + npmCommand + ' install --production && ' +
             'npm install heapdump && npm dedupe';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Sometimes services need to know if they are running inside Docker or
not in order to alter their environment. For example, the Mobile Content
Service uses request recording/playback, which should not be used when
running in Docker, so set the environment variable IN_DOCKER to signal
that.