### PR TITLE
Return all values when more than one service is started

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -66,7 +66,10 @@ Master.prototype._start = function() {
     if (self.config.num_workers === 0) {
         // No workers needed, run worker code directly.
         // FIXME: Create a Master / Worker dynamically on _start()?
-        return Worker.prototype._start.call(self);
+        return Worker.prototype._start.call(self).then(function(serviceReturns) {
+            // Wrap to match _startWorkers
+            return [serviceReturns];
+        });
     }
 
     // Fork workers.
@@ -121,9 +124,8 @@ Master.prototype._start = function() {
     .then(function() {
         return self._startWorkers(self.config.num_workers);
     })
-    .then(function(workerReturns) {
+    .tap(function() {
         self._checkHeartbeat();
-        return workerReturns;
     });
 };
 
@@ -230,7 +232,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                     self._logger.log('fatal/service-runner/master',
                         'startup failed, exiting master');
                     // Don't exit right away, allow logger to process message
-                    setTimeout(function() {  process.exit(1); }, 1000);
+                    setTimeout(function() { process.exit(1); }, 1000);
                     return;
                 }
 
@@ -246,7 +248,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                 // Let all the exit listeners fire before reassigning current worker ID
                 process.nextTick(function() {
                     self._currentStartingWorker = undefined;
-                    resolve(self._startWorkers(remainingWorkers));
+                    resolve(self._startWorkers(remainingWorkers, res));
                 });
             };
 
@@ -257,7 +259,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                         worker.removeListener('exit', workerExit);
                         self._currentStartingWorker = undefined;
                         self._firstWorkerStarted = true;
-                        res.push(msg.serviceReturns[0]);
+                        res.push(msg.serviceReturns);
                         resolve(self._startWorkers(--remainingWorkers, res));
                         break;
                     case 'heartbeat':

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -164,7 +164,7 @@ Worker.prototype._start = function() {
         self.serviceReturns = res;
         // Make sure that only JSON-serializable values are returned.
         try {
-            return [JSON.parse(JSON.stringify(res))];
+            return JSON.parse(JSON.stringify(res));
         } catch (e) {
             return [e];
         }


### PR DESCRIPTION
The README says,

> // startupResults is an array of arrays of objects returned by each
> // service. These objects should be JSON.stringify()-able.

/cc @gwicke 