### PR TITLE
Log the deprecation warning only if the logger is present; v2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -43,8 +43,10 @@ ServiceRunner.prototype.run = function run(conf) {
     return this.start(conf)
     .then(function(res) {
         // Delay the log call until the logger is actually set up.
-        self._impl._logger.log('warn/service-runner',
+        if (self._impl._logger) {
+            self._impl._logger.log('warn/service-runner',
                 'ServiceRunner.run() is deprecated, and will be removed in v3.x.');
+        }
         return res;
     });
 };


### PR DESCRIPTION
When building dokcer containers, the logger component is not
initialised. So, if the client started the build process using the
deprecated `ServiceRunner.run()` method, the process will fail.