### PR TITLE
Bug fix: Serialise the worker returns before sending them; rel v2.0.4

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -165,17 +165,19 @@ Worker.prototype._start = function() {
         });
     })
     .then(function(res) {
-        // Signal that this worker finished startup
-        if (cluster.isWorker) {
-            process.send({ type: 'startup_finished', serviceReturns: res });
-        }
+        var ret;
         self.serviceReturns = res;
         // Make sure that only JSON-serializable values are returned.
         try {
-            return JSON.parse(JSON.stringify(res));
+            ret = JSON.parse(JSON.stringify(res));
         } catch (e) {
-            return [e];
+            ret = [e];
         }
+        // Signal that this worker finished startup
+        if (cluster.isWorker) {
+            process.send({ type: 'startup_finished', serviceReturns: ret });
+        }
+        return ret;
     })
     .catch(function(e) {
         self._logger.log('fatal/service-runner/worker', e);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The worker tries to correctly serialise and deserialise the return
values before returning them. However, when there are non-serialisable
values, the worker will encounter a fatal exception when trying to send
the object to the master. This commit fixes this issue by trying to
serialise the return object first.