### PR TITLE
Log a message when startup sequence finished

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -278,6 +278,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
             });
         });
     } else {
+        self._logger.log('warn/service-runner', 'Startup finished');
         return res;
     }
 };

--- a/lib/master.js
+++ b/lib/master.js
@@ -125,6 +125,7 @@ Master.prototype._start = function() {
         return self._startWorkers(self.config.num_workers);
     })
     .tap(function() {
+        self._logger.log('warn/service-runner', 'Startup finished');
         self._checkHeartbeat();
     });
 };
@@ -278,7 +279,6 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
             });
         });
     } else {
-        self._logger.log('warn/service-runner', 'Startup finished');
         return res;
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -41,13 +41,12 @@ ServiceRunner.prototype.stop = function stop() {
 ServiceRunner.prototype.run = function run(conf) {
     var self = this;
     return this.start(conf)
-    .then(function(res) {
+    .tap(function() {
         // Delay the log call until the logger is actually set up.
         if (self._impl._logger) {
             self._impl._logger.log('warn/service-runner',
                 'ServiceRunner.run() is deprecated, and will be removed in v3.x.');
         }
-        return res;
     });
 };
 


### PR DESCRIPTION
Log a message when the startup sequence correctly finishes. 

We've had problems in Change-Prop when the worker startup sequence would just block and so not all the workers were started. As an indicator of the bug we've used a `run` method deprecation log, but with adding a proper logging we can finally stop using deprecated api in change-prop.

cc @wikimedia/services @subbuss 