### PR TITLE
Send the first heartbeat right away

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -194,6 +194,7 @@ Worker.prototype._start = function() {
 Worker.prototype._workerHeartBeat = function() {
     // We send heart beat 3 times more frequently than check it
     // to avoid possibility of wrong restarts
+    process.send({ type: 'heartbeat' });
     this.interval = setInterval(function() {
         process.send({ type: 'heartbeat' });
     }, this.config.worker_heartbeat_timeout / 3);


### PR DESCRIPTION
On startup we should send the first heartbeat right away before going to all the complex startup logic. This makes the restrictions on startup performance a bit looser.

cc @wikimedia/services 