### PR TITLE
Support building deploy repo on Mac

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -262,8 +262,10 @@ function ensureDockerVersion() {
             process.exit(1);
         }
 
-        if (os.type() === 'Darwin' && semver.lt(dockerVersion[1], '1.12.0')) {
-            console.error('Building the deploy repo on OSX supported only with docker 1.12.0+');
+        var minimumDockerVersion = os.type() === 'Darwin' ? '1.12.0' : '1.8.0';
+        if (semver.lt(dockerVersion[1], minimumDockerVersion)) {
+            console.error('Building the deploy repo on OSX supported only with docker '
+                + minimumDockerVersion + '+');
             process.exit(1);
         }
     });

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -9,6 +9,7 @@ var P = require('bluebird');
 var fs = P.promisifyAll(require('fs'));
 var path = require('path');
 var util = require('util');
+var os = require('os');
 
 // Info from the package definition
 var pkg;
@@ -169,7 +170,10 @@ function createDockerFile() {
             'RUN ' + npmCommand + ' install && npm dedupe\n';
     }
 
-    if (opts.uid !== 0) {
+    if (opts.uid !== 0
+            // In 'Docker for Mac' the mapping between users/groups
+            // is done internally by docker, so we can run as root
+            && os.type() !== 'Darwin') {
         contents += 'RUN groupadd -g ' + opts.gid + ' -r rungroup && ' +
         'useradd -m -r -g rungroup -u ' + opts.uid + ' runuser\n' +
         'USER runuser\n' + 'ENV HOME=/home/runuser LINK=g++\n';

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -10,6 +10,7 @@ var fs = P.promisifyAll(require('fs'));
 var path = require('path');
 var util = require('util');
 var os = require('os');
+var semver = require('semver');
 
 // Info from the package definition
 var pkg;
@@ -247,7 +248,26 @@ function startContainer(args, hidePorts) {
 
 }
 
+function ensureDockerVersion() {
+    return promisedSpawn(['docker', '-v'], { capture: true })
+    .then(function(dockerVersion) {
+        if (!dockerVersion) {
+            console.error('Docker is not found.');
+            process.exit(1);
+        }
 
+        dockerVersion = /(\d+\.\d+\.\d+)/.exec(dockerVersion);
+        if (!dockerVersion[1]) {
+            console.error("Couldn't find docker version. Make sure docker is installed");
+            process.exit(1);
+        }
+
+        if (os.type() === 'Darwin' && semver.lt(dockerVersion[1], '1.12.0')) {
+            console.error('Building the deploy repo on OSX supported only with docker 1.12.0+');
+            process.exit(1);
+        }
+    });
+}
 /**
  * Updates the deploy repository to current master and
  * rebuilds the node modules, committing and git-review-ing
@@ -527,7 +547,8 @@ function main(options, configuration) {
     process.chdir(opts.path);
 
     // start the process
-    return getUid()
+    return ensureDockerVersion()
+    .then(getUid)
     .then(createDockerFile)
     .then(buildImg)
     .then(function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Recently native docker for Mac beta was released (https://www.docker.com/products/docker#/mac) which removes the need to have a VirtualBox machine to host the docker daemon processes. Additionally, they've created `osxfs` (https://docs.docker.com/docker-for-mac/osxfs/) - the proxy FS that makes access to the host filesystem easy from the container. So now to support building the deploy repos on OSX we can simply run as root inside the container and all the permissions will be handled for us but docker/osxfs.

Bug: https://phabricator.wikimedia.org/T103490

cc @wikimedia/services