### PR TITLE
Docker: don't capture git-review output

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -249,22 +249,16 @@ function startContainer(args, hidePorts) {
 }
 
 function ensureDockerVersion() {
-    return promisedSpawn(['docker', '-v'], { capture: true })
+    return promisedSpawn(['docker', 'version', '--format', '{{.Server.Version}}'], { capture: true })
     .then(function(dockerVersion) {
         if (!dockerVersion) {
             console.error('Docker is not found.');
             process.exit(1);
         }
 
-        dockerVersion = /(\d+\.\d+\.\d+)/.exec(dockerVersion);
-        if (!dockerVersion[1]) {
-            console.error("Couldn't find docker version. Make sure docker is installed");
-            process.exit(1);
-        }
-
         var minimumDockerVersion = os.type() === 'Darwin' ? '1.12.0' : '1.8.0';
-        if (semver.lt(dockerVersion[1], minimumDockerVersion)) {
-            console.error('Building the deploy repo on OSX supported only with docker '
+        if (semver.lt(dockerVersion, minimumDockerVersion)) {
+            console.error('Building the deploy repo on ' + os.type() + ' supported only with docker '
                 + minimumDockerVersion + '+');
             process.exit(1);
         }

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -249,7 +249,9 @@ function startContainer(args, hidePorts) {
 }
 
 function ensureDockerVersion() {
-    return promisedSpawn(['docker', 'version', '--format', '{{.Server.Version}}'], { capture: true })
+    return promisedSpawn(['docker', 'version', '--format', '{{.Server.Version}}'], {
+        capture: true
+    })
     .then(function(dockerVersion) {
         if (!dockerVersion) {
             console.error('Docker is not found.');
@@ -258,8 +260,8 @@ function ensureDockerVersion() {
 
         var minimumDockerVersion = os.type() === 'Darwin' ? '1.12.0' : '1.8.0';
         if (semver.lt(dockerVersion, minimumDockerVersion)) {
-            console.error('Building the deploy repo on ' + os.type() + ' supported only with docker '
-                + minimumDockerVersion + '+');
+            console.error('Building the deploy repo on ' + os.type() +
+                ' supported only with docker ' + minimumDockerVersion + '+');
             process.exit(1);
         }
     });

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -281,22 +281,22 @@ function updateDeploy() {
         var argsArr = ['git'];
         Array.prototype.push.apply(argsArr, args);
         options = options || {};
-        options.capture = true;
-        options.useErrHandler = true;
+        options.capture = options.capture === undefined ? true : options.capture;
+        options.useErrHandler = options.useErrHandler === undefined ? true : options.useErrHandler;
         return promisedSpawn(argsArr, options);
     }
 
-    function chainedPgit(args) {
+    function chainedPgit(args, options) {
         var arg = args.shift();
         if (!arg) {
             return P.resolve();
         }
-        return promisedGit(arg)
+        return promisedGit(arg, options)
         .then(function(data) {
             if (args.length === 0) {
                 return P.resolve(data);
             }
-            return chainedPgit(args);
+            return chainedPgit(args, options);
         });
     }
 
@@ -440,7 +440,7 @@ function updateDeploy() {
             ['review', '-R'],
             // get back to master
             ['checkout', 'master']
-        ]).then(function() {
+        ], { capture: false }).then(function() {
             console.log('\n\nChanges sent to Gerrit for review!');
         });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Sometimes `git review` needs user interaction, for example if the gerrit username/password is not set up, or if for some reason it's trying to submit several changes. In that case if we capture the output for the user it looks like the script is stuck. At least with this user would be able to interact with git-review and figure out what's the problem.

Bug: https://phabricator.wikimedia.org/T141917
cc @wikimedia/services 