### PR TITLE
Support providing env variables for the docker script

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -185,7 +185,7 @@ function createDockerFile() {
     var envCommand = 'ENV IN_DOCKER=1';
     if (pkg.deploy.env && Object.keys(pkg.deploy.env)) {
         Object.keys(pkg.deploy.env).forEach(function(envVar) {
-            envCommand += ' ' + envVar + ' ' + pkg.deploy.env[envVar];
+            envCommand += ' ' + envVar + '=' + pkg.deploy.env[envVar];
         });
     }
     contents += envCommand + '\n';

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -150,7 +150,7 @@ function createDockerFile() {
     }
 
     contents = 'FROM ' + baseImg + '\n' +
-        'RUN apt-get update && apt-get install -y ' + extraPkgs.join(' ') +
+        'RUN apt-get update --fix-missing && apt-get install -y ' + extraPkgs.join(' ') +
         ' && rm -rf /var/lib/apt/lists/*\n';
 
     var nodeVersion = pkg.deploy.node;
@@ -185,7 +185,7 @@ function createDockerFile() {
     var envCommand = 'ENV IN_DOCKER=1';
     if (pkg.deploy.env && Object.keys(pkg.deploy.env)) {
         Object.keys(pkg.deploy.env).forEach(function(envVar) {
-            envCommand += ' ' + envVar + '=' + pkg.deploy.env[envVar];
+            envCommand += ' ' + envVar + '="' + pkg.deploy.env[envVar] + '"';
         });
     }
     contents += envCommand + '\n';

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -182,7 +182,13 @@ function createDockerFile() {
         contents += 'ENV HOME=/root/ LINK=g++\n';
     }
 
-    contents += 'ENV IN_DOCKER=1\n';
+    var envCommand = 'ENV IN_DOCKER=1';
+    if (pkg.deploy.env && Object.keys(pkg.deploy.env)) {
+        Object.keys(pkg.deploy.env).forEach(function(envVar) {
+            envCommand += ' ' + envVar + ' ' + pkg.deploy.env[envVar];
+        });
+    }
+    contents += envCommand + '\n';
 
     if (opts.deploy) {
         contents += 'CMD ' + npmCommand + ' install --production && ' +

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Here's why I need this: the new kafka driver by default builds `librdkafka` from sources, which is fine for normal clients / local testing etc, since you don't expect the user to install binary packages. However, for production we are going to use debian package for `librdkafka` and build the native node bindings against it. That is controlled by setting a `BUILD_LIBRDKAFKA` env variable during the build - so we need service-runner to be able to set this variable.

cc @wikimedia/services 