### PR TITLE
Docker: Do not remove .txt files

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -420,7 +420,7 @@ function updateDeploy() {
                 '-regextype',
                 'posix-egrep',
                 '-iregex',
-                '(.*\\.git.*|.*\\.md|.*\\.txt|.*readme|.*licence)',
+                '(.*\\.git.*|.*\\.md|.*readme|.*licence)',
                 '-exec', 'rm', '-rf', '{}', ';'
             ], { capture: true, ignoreErr: true });
         }).then(function() {


### PR DESCRIPTION
Some packages use .txt files as data files, so don't remove them
forcefully.