### PR TITLE
Don't set two exit listeners simultationsly

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -76,24 +76,6 @@ Master.prototype._start = function() {
     this._logger.log('info/service-runner', 'master(' + process.pid + ') initializing '
         + this.config.num_workers + ' workers');
 
-    cluster.on('exit', function(worker) {
-        if (!self._shuttingDown
-                && !self._inRollingRestart
-                && self._currentStartingWorker !== worker.process.pid) {
-            var exitCode = worker.process.exitCode;
-            var info = {
-                message: 'worker ' + worker.process.pid + ' died (' + exitCode + '), restarting.'
-            };
-            if (self.workerStatusMap[worker.process.pid]
-                    && self.workerStatusMap[worker.process.pid].status) {
-                info.status = self.workerStatusMap[worker.process.pid].status;
-            }
-            self._logger.log('error/service-runner/master', info);
-            delete self.workerStatusMap[worker.process.pid];
-            P.delay(Math.random() * 2000).then(function() { self._startWorkers(1); });
-        }
-    });
-
     function shutdownMaster() {
         self.stop()
         .then(function() {
@@ -226,7 +208,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                 body: yaml.dump(self.config)
             });
 
-            var workerExit = function(code) {
+            var startupWorkerExit = function(code) {
                 if (!self._firstWorkerStarted
                         && self._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
                     // We tried to start the first worker 3 times, but never succeed. Give up.
@@ -253,11 +235,31 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                 });
             };
 
-            worker.on('exit', workerExit);
+            var workerExit = function(worker) {
+                if (!self._shuttingDown
+                    && !self._inRollingRestart
+                    && self._currentStartingWorker !== worker.process.pid) {
+                    var exitCode = worker.process.exitCode;
+                    var info = {
+                        message: 'worker ' + worker.process.pid
+                            + ' died (' + exitCode + '), restarting.'
+                    };
+                    if (self.workerStatusMap[worker.process.pid]
+                        && self.workerStatusMap[worker.process.pid].status) {
+                        info.status = self.workerStatusMap[worker.process.pid].status;
+                    }
+                    self._logger.log('error/service-runner/master', info);
+                    delete self.workerStatusMap[worker.process.pid];
+                    P.delay(Math.random() * 2000).then(function() { self._startWorkers(1); });
+                }
+            };
+
+            worker.on('exit', startupWorkerExit);
             worker.on('message', function(msg) {
                 switch (msg.type) {
                     case 'startup_finished':
-                        worker.removeListener('exit', workerExit);
+                        worker.removeListener('exit', startupWorkerExit);
+                        worker.on('exit', function() { workerExit(worker); });
                         self._currentStartingWorker = undefined;
                         self._firstWorkerStarted = true;
                         res.push(msg.serviceReturns);
@@ -302,7 +304,7 @@ Master.prototype._checkHeartbeat = function() {
                         message: 'worker ' + worker.process.pid
                             + ' stopped sending heartbeats, killing.'
                     };
-                    if (lastBeat.status) {
+                    if (lastBeat && lastBeat.status) {
                         info.status = lastBeat.status;
                     }
                     self._logger.log('error/service-runner/master', info);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
When the worker starts up we set a specific exit listener, but also we set a cluster-wide exit listener. In some testing I managed to get worker in the state when it died during startup in the particular moment and both listeners fired spawning 2 workers instead of a single dead one. So instead of setting 2 listeners simultaneously replace the startup one with the normal one when worker reports it's startup finished properly.

Also there was a bug when worker didn't ever send any heartbeats master had an exception.

cc @wikimedia/services 