### PR TITLE
Ignore DNS resolution issues on logstash stream

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -51,15 +51,15 @@ function Logger(confOrLogger, args) {
 
 var streamConverter = {
     gelf: function(stream, conf) {
-        // Convert the 'gelf' logger type to a real logger
-        var gs = gelfStream.forBunyan(stream.host, stream.port, stream.options);
-        gs.on('error', function(err) {
+        var impl = gelfStream.forBunyan(stream.host, stream.port, stream.options);
+        impl.on('error', function() {
             // Ignore, can't do anything, let's hope other streams will succeed
         });
+        // Convert the 'gelf' logger type to a real logger
         return {
             type: 'raw',
-            stream: gs,
-            level: stream.level || conf.level
+            stream: impl,
+            level: impl.level || conf.level
         };
     },
     stdout: function(stream, conf) {
@@ -89,14 +89,18 @@ var streamConverter = {
         };
     },
     syslog: function(stream, conf) {
+        var impl = syslogStream.createBunyanStream({
+            facility: stream.facility || 'local0',
+            host: stream.host || '127.0.0.1',
+            port: stream.port || 514
+        });
+        impl.on('error', function() {
+            // Ignore, can't do anything, let's hope other streams will succeed
+        });
         return {
             level: stream.level || conf.level,
             type: 'raw',
-            stream: syslogStream.createBunyanStream({
-                facility: stream.facility || 'local0',
-                host: stream.host || '127.0.0.1',
-                port: stream.port || 514
-            })
+            stream: impl
         };
     }
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -52,10 +52,13 @@ function Logger(confOrLogger, args) {
 var streamConverter = {
     gelf: function(stream, conf) {
         // Convert the 'gelf' logger type to a real logger
+        var gs = gelfStream.forBunyan(stream.host, stream.port, stream.options);
+        gs.on('error', function(err) {
+            // Ignore, can't do anything, let's hope other streams will succeed
+        });
         return {
             type: 'raw',
-            stream: gelfStream.forBunyan(stream.host,
-                stream.port, stream.options),
+            stream: gs,
             level: stream.level || conf.level
         };
     },

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -59,7 +59,7 @@ var streamConverter = {
         return {
             type: 'raw',
             stream: impl,
-            level: impl.level || conf.level
+            level: stream.level || conf.level
         };
     },
     stdout: function(stream, conf) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Recent failure of change-prop was caused by this - we don't catch DNS resolution errors on self stream, so they end up in the unhandledException handler and kill the worker. Logging should not kill worker, so just ignore and hope other streams will deliver our message.

cc @wikimedia/services 