### PR TITLE
Don't restart starting worker if shutting down

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -34,7 +34,6 @@ function Master(options) {
     this._shuttingDown = false;
     // Are we performing a rolling restart?
     this._inRollingRestart = false;
-    this._currentStartingWorker = undefined;
     this._firstWorkerStarted = false;
     this._firstWorkerStartupAttempts = 0;
     this.workerStatusMap = {};
@@ -209,6 +208,10 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
             });
 
             var startupWorkerExit = function(code) {
+                if (self._shuttingDown || self._inRollingRestart) {
+                    return;
+                }
+
                 if (!self._firstWorkerStarted
                         && self._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
                     // We tried to start the first worker 3 times, but never succeed. Give up.
@@ -230,28 +233,27 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
 
                 // Let all the exit listeners fire before reassigning current worker ID
                 process.nextTick(function() {
-                    self._currentStartingWorker = undefined;
                     resolve(self._startWorkers(remainingWorkers, res));
                 });
             };
 
             var workerExit = function(worker) {
-                if (!self._shuttingDown
-                    && !self._inRollingRestart
-                    && self._currentStartingWorker !== worker.process.pid) {
-                    var exitCode = worker.process.exitCode;
-                    var info = {
-                        message: 'worker ' + worker.process.pid
-                            + ' died (' + exitCode + '), restarting.'
-                    };
-                    if (self.workerStatusMap[worker.process.pid]
-                        && self.workerStatusMap[worker.process.pid].status) {
-                        info.status = self.workerStatusMap[worker.process.pid].status;
-                    }
-                    self._logger.log('error/service-runner/master', info);
-                    delete self.workerStatusMap[worker.process.pid];
-                    P.delay(Math.random() * 2000).then(function() { self._startWorkers(1); });
+                if (self._shuttingDown || self._inRollingRestart) {
+                    return;
                 }
+
+                var exitCode = worker.process.exitCode;
+                var info = {
+                    message: 'worker ' + worker.process.pid
+                        + ' died (' + exitCode + '), restarting.'
+                };
+                if (self.workerStatusMap[worker.process.pid]
+                    && self.workerStatusMap[worker.process.pid].status) {
+                    info.status = self.workerStatusMap[worker.process.pid].status;
+                }
+                self._logger.log('error/service-runner/master', info);
+                delete self.workerStatusMap[worker.process.pid];
+                P.delay(Math.random() * 2000).then(function() { self._startWorkers(1); });
             };
 
             worker.on('exit', startupWorkerExit);
@@ -260,7 +262,6 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                     case 'startup_finished':
                         worker.removeListener('exit', startupWorkerExit);
                         worker.on('exit', function() { workerExit(worker); });
-                        self._currentStartingWorker = undefined;
                         self._firstWorkerStarted = true;
                         res.push(msg.serviceReturns);
                         resolve(self._startWorkers(--remainingWorkers, res));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
In case master is shutting down and the worker died exactly at that moment we shouldn't restart it.

Also got rid of `currentlyStartingWorker` property as we don't need it any more after we've stopped setting the global `cluster.on('exit')` callback

cc @wikimedia/services 