### PR TITLE
Allow env vars and per-service app_base_path config; release v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,17 @@ services:
         # more per-service config settings
 ```
 
+In the configuration file itself, you can also use environment variables:
+
+```yaml
+field: '{env(ENV_VAR_NAME[,default_value])}'
+```
+
+The service's environment will be inspected, and if the value of `ENV_VAR_NAME`
+is defined, it will be used in the configuration. Additionally, one can also
+supply a default value in case the environment does not contain the sought
+value.
+
 All file paths in the config are relative to the application base path. 
 The base path is an absolute path to the folder where your application 
 is located (where `package.json` file is located).

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -183,6 +183,23 @@ BaseService.prototype._sanitizeConfig = function(conf, options) {
 };
 
 
+BaseService.prototype._replaceEnvVars = function(config) {
+    var envRegex = /\{\s*env\(([^,\s\)]+),?\s*([^\)]+)?\)\s*}/g;
+    if (Buffer.isBuffer(config)) {
+        config = config.toString();
+    }
+    return config.replace(envRegex, function(match, envName, defValue) {
+        if (process.env[envName] !== undefined) {
+            return process.env[envName];
+        }
+        if (defValue !== undefined) {
+            return defValue;
+        }
+        return '';
+    });
+};
+
+
 /**
  * Loads the config from file, serialized input or Object
  *
@@ -201,7 +218,7 @@ BaseService.prototype._loadConfig = function _loadConfig(conf) {
     } else if (conf && typeof conf === 'string') {
         // Yaml source provided as config string
         action = P.try(function() {
-            return yaml.load(conf);
+            return yaml.load(self._replaceEnvVars(conf));
         });
     } else {
         // No config provided - load from file and parse yaml.
@@ -212,7 +229,7 @@ BaseService.prototype._loadConfig = function _loadConfig(conf) {
         }
         action = fs.readFileAsync(configFile)
         .then(function(yamlSource) {
-            return yaml.load(yamlSource);
+            return yaml.load(self._replaceEnvVars(yamlSource));
         });
     }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -143,9 +143,12 @@ Worker.prototype._start = function() {
     // Require service modules and start them
     return P.map(this.config.services, function(service) {
         var name = service.name || service.module;
+        var basePath = service.app_base_path ?
+            path.resolve(self._basePath, service.app_base_path) :
+            self._basePath;
         var opts = {
             name: name,
-            appBasePath: self._basePath,
+            appBasePath: basePath,
             config: service.conf,
             logger: self._logger.child({
                 name: name,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.0.13",
+  "version": "2.1.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
When multiple services are declared in the config, they might not be able to have the same base path, so allow them to specify their own. The per-service base path does not have to be an absolute one, it can be relative to the global application base path.

Also, allow users to specify environment variables directly in `config.yaml` by using the construct
```yaml
field: '{env(ENV_VAR_NAME, defaultValue)}'
```

The replacement take place in the master process and then passed on to the workers. If an environment variable's value is not defined, the user can provide a default value.