### PR TITLE
Adopt yargs@5.0.0

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -77,52 +77,59 @@ BaseService.prototype._getOptions = function(opts) {
     // check process arguments
     var args = require('yargs')
     .usage('Usage: $0 [command] [options]')
-    .command('docker-start', 'starts the service in a Docker container')
-    .command('docker-test', 'starts the test process in a Docker container')
-    .command('build', 'builds the service\'s package and deploy repo')
     .options({
         n: {
             alias: 'num-workers',
             default: -1,
             describe: 'number of workers to start',
-            nargs: 1
+            nargs: 1,
+            global: true
         },
         c: {
             alias: 'config',
             default: './config.yaml',
             describe: 'YAML-formatted configuration file',
             type: 'string',
-            nargs: 1
-        },
-        f: {
-            alias: 'force',
-            default: false,
-            describe: 'force the operation to execute',
-            type: 'boolean'
-        },
-        d: {
-            alias: 'deploy-repo',
-            default: false,
-            describe: 'build only the deploy repo',
-            type: 'boolean'
-        },
-        r: {
-            alias: 'review',
-            default: false,
-            describe: 'send the patch to Gerrit after building the repo',
-            type: 'boolean'
+            nargs: 1,
+            global: true
         },
         verbose: {
             default: false,
             describe: 'be verbose',
-            type: 'boolean'
+            type: 'boolean',
+            global: true
         },
         v: {
             alias: 'version',
             default: false,
             describe: 'print the service\'s version and exit',
-            type: 'boolean'
-        },
+            type: 'boolean',
+            global: true
+        }
+    })
+    .command('docker-start', 'starts the service in a Docker container')
+    .command('docker-test', 'starts the test process in a Docker container')
+    .command('build', 'builds the service\'s package and deploy repo', function(yargs) {
+        return yargs.option({
+            f: {
+                alias: 'force',
+                default: false,
+                describe: 'force the operation to execute',
+                type: 'boolean'
+            },
+            d: {
+                alias: 'deploy-repo',
+                default: false,
+                describe: 'build only the deploy repo',
+                type: 'boolean'
+            },
+            r: {
+                alias: 'review',
+                default: false,
+                describe: 'send the patch to Gerrit after building the repo',
+                type: 'boolean'
+            }
+        });
     })
     .help('h')
     .alias('h', 'help')

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-yaml": "^3.6.1",
     "limitation": "^0.1.9",
     "semver": "^5.3.0",
-    "yargs": "^4.8.1"
+    "yargs": "^5.0.0"
   },
   "devDependencies": {
     "mocha": "^3.0.2",


### PR DESCRIPTION
Follow-up, let's go back to args@5.0.0. I thought they've had a bug, but that's just not that well documented breaking change. No need to release a new version, nothing is changed really

cc @wikimedia/services 