### PR TITLE
Support providing multiple servers in gelf config

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ logging:
   - type: gelf
     host: logstash1003.eqiad.wmnet
     port: 12201
+    # Alternatively you can provide a comma-separated list of host:port pairs,
+    # the server to use will be selected randomly on startup
+    # uris: logstash1001.eqiad.wmnet:12201,logstash1003.eqiad.wmnet:12201
 
 # Statsd metrics reporter
 metrics:

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -51,7 +51,17 @@ function Logger(confOrLogger, args) {
 
 var streamConverter = {
     gelf: function(stream, conf) {
-        var impl = gelfStream.forBunyan(stream.host, stream.port, stream.options);
+        var host = stream.host;
+        var port = stream.port;
+        if (stream.uris) {
+            var hosts = stream.uris.split(',');
+            var selectedHost = hosts[Math.floor(Math.random() * hosts.length)];
+            host = selectedHost.substr(0, selectedHost.indexOf(':'));
+            port = parseInt(selectedHost.substr(selectedHost.indexOf(':') + 1));
+        }
+
+        var impl = gelfStream.forBunyan(host, port, stream.options);
+        console.log(host, port);
         impl.on('error', function() {
             // Ignore, can't do anything, let's hope other streams will succeed
         });

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -55,13 +55,18 @@ var streamConverter = {
         var port = stream.port;
         if (stream.uris) {
             var hosts = stream.uris.split(',');
-            var selectedHost = hosts[Math.floor(Math.random() * hosts.length)];
-            host = selectedHost.substr(0, selectedHost.indexOf(':'));
-            port = parseInt(selectedHost.substr(selectedHost.indexOf(':') + 1));
+            var selectedURI = hosts[Math.floor(Math.random() * hosts.length)];
+            var selectedHost = selectedURI.substr(0, selectedURI.indexOf(':'));
+            var selectedPort = parseInt(selectedHost.substr(selectedHost.indexOf(':') + 1));
+
+            if (selectedHost && !Number.isNaN(selectedPort)) {
+                host = selectedHost;
+                port = selectedPort;
+            }
         }
 
         var impl = gelfStream.forBunyan(host, port, stream.options);
-        console.log(host, port);
+
         impl.on('error', function() {
             // Ignore, can't do anything, let's hope other streams will succeed
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
One of the blockers in moving RESTBase to the generic puppet service module is the fact that RESTBase and other services use different logstash hosts. Support providing a list of logstash hosts in the config and randomly selecting one on startup, that would end up in better load-balancing for logstash.

cc @wikimedia/services 