### PR TITLE
Check if the worker exists

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -131,7 +131,7 @@ Master.prototype._rollingRestart = function() {
 Master.prototype._stopWorker = function(workerId) {
     var self = this;
     var worker = cluster.workers[workerId];
-    if (worker.state === 'disconnected') {
+    if (!worker || worker.state === 'disconnected') {
         delete self.workerStatusMap[worker.process.pid];
         return;
     }


### PR DESCRIPTION
It's possible to run in a little raise condition - if the worker dies right about the time we were going to destroy it with the lack of heartbeat, the internal master's worker map might not have the worker any more.

Minor issue, just noticed it in the logs today.

cc @wikimedia/services 