### PR TITLE
Provide the worker id to the service

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -194,7 +194,7 @@ Master.prototype._onStatusReceived = function(worker, status) {
 
 // Fork off one worker at a time, once the previous worker has finished
 // startup.
-Master.prototype._startWorkers = function(remainingWorkers, res) {
+Master.prototype._startWorkers = function(remainingWorkers, res, worker_id) {
     res = res || [];
     var self = this;
     if (remainingWorkers) {
@@ -203,9 +203,11 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
         self._saveBeat(worker);
         return new P(function(resolve) {
             fixCloseDisconnectListeners(worker);
+            var workerId = worker_id || (self.config.num_workers - remainingWorkers + 1);
             var config = Object.assign({}, self.config, {
-                worker_id: self.config.num_workers - remainingWorkers + 1
+                worker_id: workerId
             });
+            worker.worker_id = workerId;
             worker.send({
                 type: 'config',
                 body: yaml.dump(config)
@@ -256,7 +258,9 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
                 }
                 self._logger.log('error/service-runner/master', info);
                 delete self.workerStatusMap[worker.process.pid];
-                P.delay(Math.random() * 2000).then(function() { self._startWorkers(1); });
+                P.delay(Math.random() * 2000).then(function() {
+                    self._startWorkers(1, undefined, worker.worker_id);
+                });
             };
 
             worker.on('exit', startupWorkerExit);

--- a/lib/master.js
+++ b/lib/master.js
@@ -194,7 +194,7 @@ Master.prototype._onStatusReceived = function(worker, status) {
 
 // Fork off one worker at a time, once the previous worker has finished
 // startup.
-Master.prototype._startWorkers = function(remainingWorkers, res, worker_id) {
+Master.prototype._startWorkers = function(remainingWorkers, res, workerId) {
     res = res || [];
     var self = this;
     if (remainingWorkers) {
@@ -203,7 +203,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res, worker_id) {
         self._saveBeat(worker);
         return new P(function(resolve) {
             fixCloseDisconnectListeners(worker);
-            var workerId = worker_id || (self.config.num_workers - remainingWorkers + 1);
+            workerId = workerId || (self.config.num_workers - remainingWorkers + 1);
             var config = Object.assign({}, self.config, {
                 worker_id: workerId
             });

--- a/lib/master.js
+++ b/lib/master.js
@@ -63,6 +63,7 @@ Master.prototype._start = function() {
     var self = this;
 
     if (self.config.num_workers === 0) {
+        self.config.worker_id = 0;
         // No workers needed, run worker code directly.
         // FIXME: Create a Master / Worker dynamically on _start()?
         return Worker.prototype._start.call(self).then(function(serviceReturns) {
@@ -202,11 +203,13 @@ Master.prototype._startWorkers = function(remainingWorkers, res) {
         self._saveBeat(worker);
         return new P(function(resolve) {
             fixCloseDisconnectListeners(worker);
+            var config = Object.assign({}, self.config, {
+                worker_id: self.config.num_workers - remainingWorkers + 1
+            });
             worker.send({
                 type: 'config',
-                body: yaml.dump(self.config)
+                body: yaml.dump(config)
             });
-
             var startupWorkerExit = function(code) {
                 if (self._shuttingDown || self._inRollingRestart) {
                     return;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -146,6 +146,7 @@ Worker.prototype._start = function() {
         var basePath = service.app_base_path ?
             path.resolve(self._basePath, service.app_base_path) :
             self._basePath;
+        service.conf.worker_id = self.config.worker_id;
         var opts = {
             name: name,
             appBasePath: basePath,
@@ -155,7 +156,7 @@ Worker.prototype._start = function() {
             }),
             // todo: set up custom prefix
             metrics: self._metrics,
-            ratelimiter: self._ratelimiter,
+            ratelimiter: self._ratelimiter
         };
 
         return self._requireModule(service.module || service.name)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.8",
+  "version": "2.1.9",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
In the trending service we would need to construct a stable consumer group id unique for each worker. We could use the `os.hostname()` to differentiate the workers between the hosts, but for workers on the same host we need a stable unique id. A sequential number of the worker in startup sequence could work as such an id, so forward it to the service together with the service configuration.

This problem could've been solved my having just one worker per host, but in case the worker dies, spawning the new one will take quite some time, and in the meantime all requests to a particular host would fail. So it's better to be able to have 2 workers per node.

cc @wikimedia/services 