### PR TITLE
Allow installing custom deb packages

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -123,6 +123,8 @@ function createDockerFile() {
     // 'packages' is an array of package names
     // 'repo_url' and 'pool' combinations are unique
     var customSourcePkgs = [];
+    // An array of URIs of custom .deb packages to be installed
+    var debPkgs = [];
 
     // set some defaults
     if (!pkg.deploy) {
@@ -153,11 +155,15 @@ function createDockerFile() {
                 if (typeof pkg === 'string') {
                     extraPkgs.push(pkg);
                 } else if (typeof pkg === 'object') {
-                    if (!pkg.repo_url || !pkg.pool || !pkg.packages || !pkg.release) {
-                        console.error('ERROR: Incorrect dependency spec: ' + JSON.stringify(pkg));
-                        process.exit(1);
+                    if (pkg.uri) {
+                        debPkgs.push(pkg.uri);
+                    } else {
+                        if (!pkg.repo_url || !pkg.pool || !pkg.packages || !pkg.release) {
+                            console.error('ERROR: Incorrect dependency spec: ' + JSON.stringify(pkg));
+                            process.exit(1);
+                        }
+                        customSourcePkgs.push(pkg);
                     }
-                    customSourcePkgs.push(pkg);
                 } else {
                     console.error('ERROR: Incorrect dependency spec: ' + pkg);
                     process.exit(1);
@@ -188,6 +194,12 @@ function createDockerFile() {
                 return 'apt-get install -y --force-yes -t ' +
                     customSourcePkgSpec.release + ' ' + customSourcePkgSpec.packages.join(' ');
             }).join(' && ') + ' && rm -rf /var/lib/apt/lists/*\n';
+    }
+
+    if (debPkgs.length) {
+        contents += 'RUN ' + debPkgs.map(function(uri) {
+                return 'wget ' + uri + ' -O package.deb && dpkg -i package.deb && rm package.deb'
+            }).join(' && ') + '\n';
     }
 
     var nodeVersion = pkg.deploy.node;


### PR DESCRIPTION
For kartoterian support on node 6 and jessie for now we need to install libmapnik packages Faidon has built. Add support for installing custom deb packages from some URIs.

We might wanna delete this feature eventually, but for now there's no real way around

cc @wikimedia/services @nyurik 