### PR TITLE
Allow additional install options in the build script

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -247,7 +247,11 @@ function createDockerFile() {
             beforeInstall = 'rm -f npm-shrinkwrap.json && ';
             afterInstall = '&& npm shrinkwrap ';
         }
-        contents += 'CMD ' + beforeInstall + npmCommand + ' install --production ' + afterInstall +
+        var installOpts = ' --production ';
+        if (pkg.deploy.install_opts) {
+            installOpts += pkg.deploy.install_opts.join(' ') + ' ';
+        }
+        contents += 'CMD ' + beforeInstall + npmCommand + ' install' + installOpts + afterInstall +
             ' && npm install heapdump ';
         if (!opts.reshrinkwrap) {
             contents += '&& ! [ -e npm-shrinkwrap.json ] && npm dedupe ';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.14",
+  "version": "2.1.15",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
For kartotherian we need to provide --build-from-source=mapnik --fallback-to-build=false options to the `npm install` command, allow that.

cc @wikimedia/services @nyurik 