### PR TITLE
Added support for specifying the repo key

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -107,6 +107,15 @@ function promisedSpawn(args, options) {
 
 }
 
+function generateCustomSourcesKeyFetch(customSourcePkgs) {
+    customSourcePkgs = customSourcePkgs.filter(function(pkgSpec) { return pkgSpec.key_url; });
+    if (customSourcePkgs.length) {
+        return 'RUN ' + customSourcePkgs.map(function(pkgSpec) {
+                return ' wget -O key "' + pkgSpec.key_url + '" && apt-key add key && rm key ';
+            }).join('&&') + '\n';
+    }
+    return '';
+}
 
 /**
  * Generates the Dockerfile used to build the image and start the container
@@ -190,9 +199,12 @@ function createDockerFile() {
                     ' ' + customSourcePkgSpec.release +
                     ' ' + customSourcePkgSpec.pool + '" >> /etc/apt/sources.list';
             }).join(' && ') + '\n';
+
+        contents += generateCustomSourcesKeyFetch(customSourcePkgs);
+
         contents += 'RUN apt-get update && '
             + customSourcePkgs.map(function(customSourcePkgSpec) {
-                return 'apt-get install -y --force-yes -t ' +
+                return 'apt-get install -y -t ' +
                     customSourcePkgSpec.release + ' ' + customSourcePkgSpec.packages.join(' ');
             }).join(' && ') + ' && rm -rf /var/lib/apt/lists/*\n';
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.11",
+  "version": "2.1.12",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
@paravoid correctly pointed out that using `--force-yes` when installing packages from WMF apt repo is a terrible practice (https://gerrit.wikimedia.org/r/#/c/322368/), so add support for providing key URL so that we could fetch the key to the repo and properly add it to apt-get

cc @wikimedia/services 