### PR TITLE
Added ability for lazy log payload creation

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -296,27 +296,42 @@ Logger.prototype._log = function(info, level, levelPath, logger) {
     }
 };
 
-Logger.prototype.log = function(level, info) {
+/**
+ * Logs and info object with a specified level
+ * @param {string} level Log level and components, for example 'trace/request'
+ * @param {Object|Function} info log statement object, or a callback to lazily construct the log statement
+ *                               after we've decided that this particular level will be matched.
+ * @param {boolean} [force] optional argument to force sampled component logging even
+ *                          if the probability wasn't met. Used together with `isLoggable`
+ */
+Logger.prototype.log = function(level, info, force) {
     var simpleLevel;
     if (!level || !info) {
         return;
     }
 
+    function getLog(info) {
+        if (typeof info === "function") {
+            return info();
+        }
+        return info;
+    }
+
     if (Logger.logTrace) {
         simpleLevel = extractSimpleLevel(level);
         if (simpleLevel) {
-            this._log(info, simpleLevel, level, this._traceLogger);
+            this._log(getLog(info), simpleLevel, level, this._traceLogger);
         }
         return;
     }
 
     simpleLevel = this._getSimpleLogLevel(level);
     if (simpleLevel) {
-        this._log(info, simpleLevel, level, this._logger);
+        this._log(getLog(info), simpleLevel, level, this._logger);
     } else {
-        var componentLoggerConf = this._getComponentLogConfig(level);
+        var componentLoggerConf = this._getComponentLogConfig(level, force);
         if (componentLoggerConf) {
-            this._log(info, componentLoggerConf.level, level, componentLoggerConf.logger);
+            this._log(getLog(info), componentLoggerConf.level, level, componentLoggerConf.logger);
         }
     }
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -299,8 +299,9 @@ Logger.prototype._log = function(info, level, levelPath, logger) {
 /**
  * Logs and info object with a specified level
  * @param {string} level Log level and components, for example 'trace/request'
- * @param {Object|Function} info log statement object, or a callback to lazily construct the log statement
- *                               after we've decided that this particular level will be matched.
+ * @param {Object|Function} info log statement object, or a callback to lazily construct
+ *                               the log statement after we've decided that this particular
+ *                               level will be matched.
  * @param {boolean} [force] optional argument to force sampled component logging even
  *                          if the probability wasn't met. Used together with `isLoggable`
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.12",
+  "version": "2.1.13",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
After playing with node 6 new feature `--inspect` and profiling change-prop a bit I've realised that about 10% of the CPU is spent in constructing logging statements, because we need to stringify events to avoid logstash issues. But most of the logs never actually make it, so all this effort is lost. 

The idea is to accept a callback function to lazily construct the log payload after we've decided that it's needed. Other option was to create an `isLoggable` method and add an `if` statement on the call, but figuring out if the level is loggable is a pretty expensive process so we don't want to repeat it twice.

cc @wikimedia/services 