### PR TITLE
Docker: Allow only the Dockerfile to be generated

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -109,33 +109,51 @@ BaseService.prototype._getOptions = function(opts) {
     })
     .command('docker-start', 'starts the service in a Docker container')
     .command('docker-test', 'starts the test process in a Docker container')
-    .command('build', 'builds the service\'s package and deploy repo', function(yargs) {
-        return yargs.option({
-            f: {
-                alias: 'force',
-                default: false,
-                describe: 'force the operation to execute',
-                type: 'boolean'
-            },
-            d: {
-                alias: 'deploy-repo',
-                default: false,
-                describe: 'build only the deploy repo',
-                type: 'boolean'
-            },
-            s: {
-                alias: 'reshrinkwrap',
-                default: false,
-                describe: 'rebuild shrinkwrap.json by removing and regenerating after npm install',
-                type: 'boolean'
-            },
-            r: {
-                alias: 'review',
-                default: false,
-                describe: 'send the patch to Gerrit after building the repo',
-                type: 'boolean'
-            }
-        });
+    .command('build', 'builds the service\'s package and deploy repo', {
+        f: {
+            alias: 'force',
+            default: false,
+            describe: 'force the operation to execute',
+            type: 'boolean'
+        },
+        d: {
+            alias: 'deploy-repo',
+            default: false,
+            describe: 'build only the deploy repo',
+            type: 'boolean'
+        },
+        s: {
+            alias: 'reshrinkwrap',
+            default: false,
+            describe: 'rebuild shrinkwrap.json by removing and regenerating after npm install',
+            type: 'boolean'
+        },
+        r: {
+            alias: 'review',
+            default: false,
+            describe: 'send the patch to Gerrit after building the repo',
+            type: 'boolean'
+        }
+    })
+    .command('generate', 'generates the Dockerfile specification for the service', {
+        r: {
+            alias: 'running',
+            default: false,
+            describe: 'generate the Dockerfile to start the service',
+            type: 'boolean'
+        },
+        t: {
+            alias: 'testing',
+            default: false,
+            describe: 'generate the Dockerfile to test the service',
+            type: 'boolean'
+        },
+        b: {
+            alias: 'building',
+            default: false,
+            describe: 'generate the Dockerfile to build the deployment repository',
+            type: 'boolean'
+        },
     })
     .help('h')
     .alias('h', 'help')
@@ -145,10 +163,11 @@ BaseService.prototype._getOptions = function(opts) {
     args.build = args._.indexOf('build') !== -1 || args.deployRepo;
     args.dockerStart = args._.indexOf('docker-start') !== -1;
     args.dockerTest = args._.indexOf('docker-test') !== -1;
-    args.deployRepo = args.deployRepo || args.build;
+    args.generate = args._.indexOf('generate') !== -1;
+    args.deployRepo = args.deployRepo || args.build || args.building;
 
-    if (args.build && args.dockerStart || args.build && args.dockerTest
-    || args.dockerStart && args.dockerTest) {
+    if ([args.build, args.dockerStart, args.dockerTest, args.generate]
+            .filter(function(x) { return !!x; }).length > 1) {
         console.error('Only one command can be specified!');
         process.exit(1);
     }
@@ -161,9 +180,10 @@ BaseService.prototype._getOptions = function(opts) {
         buildDeploy: args.deployRepo,
         reshrinkwrap: args.reshrinkwrap,
         sendReview: args.review,
-        dockerStart: args.dockerStart,
-        dockerTest: args.dockerTest,
-        useDocker: args.deployRepo || args.dockerStart || args.dockerTest,
+        dockerStart: args.dockerStart || args.running,
+        dockerTest: args.dockerTest || args.testing,
+        generate: args.generate,
+        useDocker: args.deployRepo || args.dockerStart || args.dockerTest || args.generate,
         force: args.force,
         verbose: args.verbose
     };

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -591,6 +591,7 @@ function main(options, configuration) {
         need_build: options.buildDeploy && options.force,
         review: options.sendReview,
         reshrinkwrap: options.reshrinkwrap,
+        generate: options.generate,
         path: options.basePath
     };
 
@@ -633,13 +634,18 @@ function main(options, configuration) {
     return ensureDockerVersion()
     .then(getUid)
     .then(createDockerFile)
-    .then(buildImg)
     .then(function() {
-        if (opts.deploy) {
-            return updateDeploy();
-        } else {
-            return startContainer();
+        if (opts.generate) {
+            return;
         }
+        return buildImg()
+        .then(function() {
+            if (opts.deploy) {
+                return updateDeploy();
+            } else {
+                return startContainer();
+            }
+        });
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "js-yaml": "^3.6.1",
     "limitation": "^0.1.9",
     "semver": "^5.3.0",
-    "yargs": "^5.0.0"
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
     "mocha": "^3.0.2",


### PR DESCRIPTION
As a first step of the containerasition effort, we need to make the
Dockerfile specification based on package.json available to other
parts of the system, most notably the build and test pipeline(s). To
that end, service-runner needs to be able to only generate the spec
without actually building nor starting the container.