### PR TITLE
Docker: Fetch all updates

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -381,8 +381,8 @@ function updateDeploy() {
         return chainedPgit([
             // make sure we are on master
             ['checkout', 'master'],
-            // fetch any possible updates
-            ['fetch', opts.remote_name],
+            // fetch all possible updates
+            ['fetch', '--all'],
             // work on a topic branch forked off of the target branch
             ['checkout', '-B', 'sync-repo', opts.remote_branch],
             // check if the submodule is present


### PR DESCRIPTION
Developers can have multiple remotes defined for the deploy repository.
Additionally, newer versions of git-review automatically create a
'gerrit' remote that is equal to 'origin', so fetch all of the updates
to avoid confusing gerrit when submitting the patch.