### PR TITLE
Docker: No need to check for Docker if it will not be used

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -318,6 +318,9 @@ function startContainer(args, hidePorts) {
 }
 
 function ensureDockerVersion() {
+    if (opts.generate) {
+        return P.resolve(true);
+    }
     return promisedSpawn(['docker', 'version', '--format', '{{.Server.Version}}'], {
         capture: true
     })


### PR DESCRIPTION
As of recently, service-runner is able to only generate the Dockerfile
specification without actually using it. In this case, there is no need
to fail if Docker is not installed on the system generating the
specification, since it will never be invoked.