### PR TITLE
Terminate the workers more gracefully

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -127,7 +127,7 @@ Master.prototype._rollingRestart = function() {
     });
 };
 
-Master.prototype._stopWorker = function(workerId) {
+Master.prototype._stopWorker = function(workerId, force) {
     var self = this;
     var worker = cluster.workers[workerId];
     if (!worker || worker.state === 'disconnected') {
@@ -156,7 +156,13 @@ Master.prototype._stopWorker = function(workerId) {
             resolve();
         });
     });
-    worker.disconnect();
+
+    if (force) {
+        worker.disconnect();
+    } else {
+        worker.send({ type: 'terminate' });
+    }
+
     return res;
 };
 
@@ -316,7 +322,7 @@ Master.prototype._checkHeartbeat = function() {
                         info.status = lastBeat.status;
                     }
                     self._logger.log('error/service-runner/master', info);
-                    self._stopWorker(workerId);
+                    self._stopWorker(workerId, true);
                     // Don't need to respawn a worker, it will be restarted upon 'exit' event
                 }
             });

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -41,6 +41,8 @@ Worker.prototype._getConfigUpdateAction = function() {
                 if (self._ratelimiter) {
                     self._ratelimiter._updateBlocks(message.value);
                 }
+            } else if (message.type === 'terminate') {
+                self.stop();
             } else {
                 reject(new Error('Invalid message received: ' + JSON.stringify(message)));
             }
@@ -68,15 +70,21 @@ Worker.prototype._getConfigUpdateAction = function() {
 Worker.prototype.stop = function() {
     var self = this;
     BaseService.prototype.stop.call(self);
+    var stoppers;
     if (Array.isArray(self.serviceReturns)) {
-        return P.each(self.serviceReturns, function(serviceRet) {
+        stoppers = P.each(self.serviceReturns, function(serviceRet) {
             if (serviceRet && typeof serviceRet.close === 'function') {
                 return serviceRet.close();
             }
         });
     } else {
-        return P.resolve();
+        stoppers = P.resolve();
     }
+    return stoppers.then(function() {
+        if (cluster.isWorker) {
+            cluster.worker.disconnect();
+        }
+    });
 };
 
 Worker.prototype._start = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.16",
+  "version": "2.1.17",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Previously our shutdown process only closed the http server, and we never actually close anything else that might need to be closed within the server if the num_workers was > 0. The procedure described [here](https://github.com/nodejs/node/issues/1305#issuecomment-88594146) would basically do the same thing for the HTTP servers as done right now by disconnect, but additionally it would provide us a way to hook into the disconnection process and close whatever the services requested.

We could've done that by adding a listener in the worker for the disconnect event, but, that's problematic because the service-provided closing handler should explicitly close the HTTP server for the num_workers === 0 case and then with num_workers > 0 case calling the service-provided close method fails because the server was already killed by the cluster module.

Also, this is more in line with what the official docs say: https://nodejs.org/dist/latest-v6.x/docs/api/cluster.html#cluster_worker_disconnect

Bug: https://phabricator.wikimedia.org/T158265
cc @wikimedia/services 