### PR TITLE
Support DNS caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ ratelimit:
   #  - 123.456.789.233
   #  - 456.789.90.2
 
+# DNS caching settings
+dns_cache:
+  ttl: 5 # Time-to-live for cache entries, in seconds
+  size: 10 # Optional cache size, default: 100
+
 services:
   - name: parsoid
     # a relative path or the name of an npm package, if different from name

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ ratelimit:
 # DNS caching settings
 dns_cache:
   ttl: 5 # Time-to-live for cache entries, in seconds
-  size: 10 # Optional cache size, default: 100
+  size: 100 # Optional cache size, default: 100
 
 services:
   - name: parsoid

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -57,6 +57,15 @@ BaseService.prototype.start = function start(conf) {
     return self._getConfigUpdateAction(conf)
     .then(function() {
         var config = self.config;
+
+        if (config.dns_cache && config.dns_cache.ttl) {
+            require('dnscache')({
+                enable: true,
+                ttl: config.dns_cache.ttl,
+                cachesize: config.dns_cache.size || 100
+            });
+        }
+
         // display the version
         if (self.options.displayVersion) {
             console.log(config.serviceName + ' ' + config.package.version);

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -59,7 +59,7 @@ function makeStatsD(options, logger) {
         prefix:  srvName + '.',
         suffix: '',
         globalize: false,
-        cacheDns: true,
+        cacheDns: false,
         mock: false
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.1.16",
+  "version": "2.2.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -37,7 +37,8 @@
     "js-yaml": "^3.8.1",
     "limitation": "^0.2.0",
     "semver": "^5.3.0",
-    "yargs": "^6.6.0"
+    "yargs": "^6.6.0",
+    "dnscache": "^1.0.1"
   },
   "devDependencies": {
     "mocha": "^3.2.0",


### PR DESCRIPTION
Added support for DNS caching and disabled internal statsd DNS caching. 

This will have quite a brutal effect on performance if we just disable internal statsd client cache and not switch on the global cache, so I've bumped the package version to 2.2.0.

Bug: https://phabricator.wikimedia.org/T158338
cc @wikimedia/services 