### PR TITLE
Correctly check whether npm-shrinkwrap exists

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -254,7 +254,7 @@ function createDockerFile() {
         contents += 'CMD ' + beforeInstall + npmCommand + ' install' + installOpts + afterInstall +
             ' && npm install heapdump ';
         if (!opts.reshrinkwrap) {
-            contents += '&& ! [ -e npm-shrinkwrap.json ] && npm dedupe ';
+            contents += '&& if ! [ -e npm-shrinkwrap.json ] ; then npm dedupe ; fi';
         }
     } else if (opts.tests) {
         contents += 'CMD ' + npmCommand + ' test';


### PR DESCRIPTION
Ok, before if the file existed docker would exit with code 1 breaking the build.

cc @wikimedia/services 