### PR TITLE
Don't bring down the service if an error occurs in the logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -22,8 +22,13 @@ function Logger(confOrLogger, args) {
         self._sampled_levels = conf.sampled_levels || {};
         delete conf.sampled_levels;
         self._logger = bunyan.createLogger(conf);
+        self._logger.on('error', function() {
+            // If some fatal error occurs in the logger,
+            // we cannot really do anything, let's just hope
+            // some of the streams succeed, but definitely
+            // don't bring down the service.
+        });
         self._levelMatcher = this._levelToMatcher(conf.level);
-
         // For each specially logged component we need to create
         // a child logger that accepts everything regardless of the level
         self._componentLoggers = {};
@@ -32,10 +37,16 @@ function Logger(confOrLogger, args) {
                 component: component,
                 level: bunyan.TRACE
             });
+            self._componentLoggers[component].on('error', function() {
+                // Don't bring down the service if can't log
+            });
         });
 
         self._traceLogger = self._logger.child({
             level: bunyan.TRACE
+        });
+        self._traceLogger.on('error', function() {
+            // Don't bring down the service if can't log
         });
         // Set up handlers for uncaught extensions
         self._setupRootHandlers();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -22,12 +22,7 @@ function Logger(confOrLogger, args) {
         self._sampled_levels = conf.sampled_levels || {};
         delete conf.sampled_levels;
         self._logger = bunyan.createLogger(conf);
-        self._logger.on('error', function() {
-            // If some fatal error occurs in the logger,
-            // we cannot really do anything, let's just hope
-            // some of the streams succeed, but definitely
-            // don't bring down the service.
-        });
+        self._addErrorHandler();
         self._levelMatcher = this._levelToMatcher(conf.level);
         // For each specially logged component we need to create
         // a child logger that accepts everything regardless of the level
@@ -37,16 +32,10 @@ function Logger(confOrLogger, args) {
                 component: component,
                 level: bunyan.TRACE
             });
-            self._componentLoggers[component].on('error', function() {
-                // Don't bring down the service if can't log
-            });
         });
 
         self._traceLogger = self._logger.child({
             level: bunyan.TRACE
-        });
-        self._traceLogger.on('error', function() {
-            // Don't bring down the service if can't log
         });
         // Set up handlers for uncaught extensions
         self._setupRootHandlers();
@@ -131,6 +120,29 @@ var streamConverter = {
     }
 };
 var streamConverterList = Object.keys(streamConverter);
+
+Logger.prototype._addErrorHandler = function() {
+    var self = this;
+    self._logger.on('error', function(err, failedStream) {
+        // If some fatal error occurred in one of the logger streams,
+        // we can't do much, so ignore.
+
+        if (err.code === 'ENOSPC') {
+            // However, if it's a `file` stream, and the error is from
+            // a filled-up disc, attempting to further write to this
+            // stream will leak memory and finally destroy the process.
+            // So remove destroy the stream and remove it.
+            self._logger.streams = self._logger.streams.filter(function(s) {
+                return s !== failedStream;
+            });
+            failedStream.stream.destroy();
+            // Hope that we have other streams to report the problem
+            self.log('fatal/service-runner/logger', {
+                msg: 'Failed to write logs to file, disc full'
+            });
+        }
+    });
+};
 
 Logger.prototype._processConf = function(conf) {
     var self = this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
I've been testing what happens when the disk partition we log to fills up. Currently that exception is not 
being handled, and the whole service (including master process) just dies. 

We don't want to bring down the whole service because of the logger, but we as well can't really handle properly any fatal logging errors, so let's just ignore them hoping that if one stream failed, other streams would succeed.

However, disk fill-up is a different situation. In that case every attempt to log something would result in a memory leak, quickly exhausting the process memory. To fix it up, we can remove the file logging stream and hope that some other streams would we able to deliver our error message.

Bug: https://phabricator.wikimedia.org/T112648