### PR TITLE
Implemented sampled rate-limiting for logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ logging:
   # regardless of the configured logging level.
   sampled_levels:
     'trace/webrequest': 0.2
+  # Set up the limiter for logging. When the rate of logs is close to the limit,
+  # it starts to increase the probability of discarding the logs of same kind.
+  # For default parameters use rate_limit: true
+  rate_limit:
+    limit: 2000 # How many per interval to log. Default: 1000
+    interval: 100 # Interval of rate sampling, ms. Default: 1000    
   streams:
   # Use gelf-stream -> logstash
   - type: gelf

--- a/lib/log_sampler.js
+++ b/lib/log_sampler.js
@@ -19,7 +19,7 @@ function Sampler(options) {
     this._counters = {};
     // Exponential decay with factor 2, thrice per interval for better
     // smoothness, using the cubic root of 2).
-    this._decayFactor = Math.pow(2, 1/3);
+    this._decayFactor = Math.pow(2, 1 / 3);
     this._decayedLimit = this._options.limit / this._decayFactor;
     this._decayInterval = setInterval(this._decay.bind(this), this._options.interval / 3);
 }

--- a/lib/log_sampler.js
+++ b/lib/log_sampler.js
@@ -1,0 +1,59 @@
+"use strict";
+
+/**
+ * Creates a log sampler. In case the log rate is not exceeded, all the logs
+ * are being written. Otherwise starts sampling the logs with decreasing
+ * probability.
+ *
+ * @param {object} options:
+ * @param {Number} [options.limit] The maximum rate of sampled logs per interval. Default: 1000.
+ * @param {Number} [options.interval] Update interval in ms. Default: 1000ms.
+ * @param {Number} [options.minValue] Drop global counters below this value. Default: 10.
+ */
+function Sampler(options) {
+    this._options = options === true ? {} : options || {};
+    this._options.limit = this._options.limit || 1000;
+    this._options.interval = this._options.interval || 1000;
+    this._options.minValue = this._options.minValue || 10;
+    // TODO: replace with a native Map when support for node 0.10 is dropped.
+    this._counters = {};
+    // Exponential decay with factor 2, thrice per interval for better
+    // smoothness, using the cubic root of 2).
+    this._decayFactor = Math.pow(2, 1/3);
+    this._decayedLimit = this._options.limit / this._decayFactor;
+    this._decayInterval = setInterval(this._decay.bind(this), this._options.interval / 3);
+}
+
+Sampler.prototype._decay = function() {
+    var self = this;
+    var minValue = self._options.minValue;
+    Object.keys(self._counters).forEach(function(key) {
+        self._counters[key] /= self._decayFactor;
+        if (self._counters[key] < minValue) {
+            delete self._counters[key];
+        }
+    });
+};
+
+Sampler.prototype._increment = function(logClass) {
+    this._counters[logClass] = this._counters[logClass] ? this._counters[logClass] + 1 : 1;
+};
+
+Sampler.prototype.shouldLog = function(logClass) {
+    this._increment(logClass);
+    var currentCount = this._counters[logClass];
+    if (currentCount < this._decayedLimit) {
+        // If it's not close to the limit yet - don't sample.
+        return true;
+    } else {
+        // We decay by 2 each interval, so the counter is roughly 1.5 time larger
+        // then continuous rate.
+        return Math.random() < 1.5 * this._decayedLimit / currentCount;
+    }
+};
+
+Sampler.prototype.stop = function() {
+    clearInterval(this._decayInterval);
+};
+
+module.exports = Sampler;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,7 +4,7 @@ var extend = require('extend');
 var bunyan = require('bunyan');
 var gelfStream = require('gelf-stream');
 var syslogStream = require('bunyan-syslog-udp');
-
+var Sampler = require('./log_sampler');
 var DEF_LEVEL = 'warn';
 var LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
 var DEF_LEVEL_INDEX = LEVELS.indexOf(DEF_LEVEL);
@@ -37,6 +37,11 @@ function Logger(confOrLogger, args) {
         self._traceLogger = self._logger.child({
             level: bunyan.TRACE
         });
+
+        if (conf.rate_limit) {
+            self._sampler = new Sampler(conf.rate_limit);
+        }
+
         // Set up handlers for uncaught extensions
         self._setupRootHandlers();
     } else {
@@ -45,6 +50,7 @@ function Logger(confOrLogger, args) {
         self._levelMatcher = confOrLogger._levelMatcher;
         self._componentLoggers = confOrLogger._componentLoggers;
         self._traceLogger = confOrLogger._traceLogger;
+        self._sampler = confOrLogger._sampler;
     }
     this.args = args;
 }
@@ -334,6 +340,10 @@ Logger.prototype.log = function(level, info) {
         return;
     }
 
+    if (this._sampler && !this._sampler.shouldLog(level)) {
+        return;
+    }
+
     function getLog(info) {
         if (typeof info === "function") {
             return info();
@@ -367,6 +377,9 @@ Logger.prototype.close = function() {
     }).forEach(function(stream) {
         stream.stream.end();
     });
+    if (this._sampler) {
+        this._sampler.stop();
+    }
 };
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
We can't reuse the existing rate_limiter, because we want a bit different thing - when the limit is about to be reached we want to probabilistically decide whether to log or not, so that we don't cut off all logging completely when the limit is reached, but instead start automatically sampling.

Bug: https://phabricator.wikimedia.org/T159479
cc @wikimedia/services 