### PR TITLE
Docker: Ignore Docker version check errors

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -331,10 +331,16 @@ function ensureDockerVersion() {
         }
 
         var minimumDockerVersion = os.type() === 'Darwin' ? '1.12.0' : '1.8.0';
-        if (semver.lt(dockerVersion, minimumDockerVersion)) {
-            console.error('Building the deploy repo on ' + os.type() +
-                ' supported only with docker ' + minimumDockerVersion + '+');
-            process.exit(1);
+        try {
+            if (semver.lt(dockerVersion, minimumDockerVersion)) {
+                console.error('Building the deploy repo on ' + os.type() +
+                    ' supported only with docker ' + minimumDockerVersion + '+');
+                process.exit(1);
+            }
+        } catch (e) {
+            // Docker has switched to the YY.MM.BB versioning scheme, and semver
+            // does not like the zero-padded numbers, so if we are here, assume that
+            // the Docker version is high enough to proceed
         }
     });
 }


### PR DESCRIPTION
Docker has recently switched to a new versioning scheme modelled after the Ubuntu one - YY.MM.BB - with zero-padded fields. Alas, semver considers such versions invalid and throws an error. Hence, if it does that, assume that the Docker installed on the system is recent enough to proceed.