### PR TITLE
Docker: Adapt version checking to the new Docker versioning scheme

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -331,6 +331,7 @@ function ensureDockerVersion() {
         }
 
         var minimumDockerVersion = os.type() === 'Darwin' ? '1.12.0' : '1.8.0';
+        dockerVersion = dockerVersion.replace(/\.0+/g, '.');
         if (semver.lt(dockerVersion, minimumDockerVersion)) {
             console.error('Building the deploy repo on ' + os.type() +
                 ' supported only with docker ' + minimumDockerVersion + '+');


### PR DESCRIPTION
Docker has switched to Ubuntu-style versioning and now uses the format YY.MM.BB. The zero-padded components do not play well with semver's version checking, so remove them so as not to confuse semver.