### PR TITLE
More verbose startup failure logging

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -219,7 +219,7 @@ Master.prototype._startWorkers = function(remainingWorkers, res, workerId) {
 
                 if (!self._firstWorkerStarted) {
                     self._logger.log('error/service-runner/master',
-                        `First worker died on startup due to ${code}`);
+                        `First worker died on startup with exit code ${code}`);
                     if (self._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
                         // We tried to start the first worker 3 times, but never succeed. Give up.
                         self._logger.log('fatal/service-runner/master',

--- a/lib/master.js
+++ b/lib/master.js
@@ -217,14 +217,17 @@ Master.prototype._startWorkers = function(remainingWorkers, res, workerId) {
                     return;
                 }
 
-                if (!self._firstWorkerStarted
-                        && self._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
-                    // We tried to start the first worker 3 times, but never succeed. Give up.
-                    self._logger.log('fatal/service-runner/master',
-                        'startup failed, exiting master');
-                    // Don't exit right away, allow logger to process message
-                    setTimeout(function() { process.exit(1); }, 1000);
-                    return;
+                if (!self._firstWorkerStarted) {
+                    self._logger.log('error/service-runner/master',
+                        `First worker died on startup due to ${code}`);
+                    if (self._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
+                        // We tried to start the first worker 3 times, but never succeed. Give up.
+                        self._logger.log('fatal/service-runner/master',
+                            'startup failed, exiting master');
+                        // Don't exit right away, allow logger to process message
+                        setTimeout(function() { process.exit(1); }, 1000);
+                        return;
+                    }
                 }
 
                 if (self._firstWorkerStarted) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Right now if the first worker we try to start fails more the `LIMIT` times we shut the master down, because most likely it's an irrecoverable error, something like SyntaxError.

However, for the first `LIMIT-1` attempts we don't log anything. There's not much important info to log, but at least we could log the exit code for easier debugging.

cc @wikimedia/services @MaxSem 