### PR TITLE
Expose logger / metrics configs to workers

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -138,7 +138,9 @@ class Worker extends BaseService {
             } else {
                 basePath = this._basePath;
             }
-            service.conf.worker_id = this.config.worker_id;
+            ['worker_id', 'logging', 'metrics', 'num_workers'].forEach((k) => {
+                service.conf[k] = this.config[k];
+            });
             const opts = {
                 name,
                 appBasePath: basePath,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "eslint-config-node-services": "^2.1.1",
+    "eslint-config-wikimedia": "^0.4.0",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-jsdoc": "^3.0.2",
     "mocha": "^3.2.0",

--- a/service-runner.js
+++ b/service-runner.js
@@ -12,6 +12,8 @@
 const cluster = require('cluster');
 const Master = require('./lib/master');
 const Worker = require('./lib/worker');
+const Logger = require('./lib/logger');
+const makeStatsD = require('./lib/statsd');
 
 // Disable cluster RR balancing; direct socket sharing has better throughput /
 // lower overhead. Also bump up somaxconn with this command:
@@ -52,6 +54,9 @@ class ServiceRunner {
             }
         });
     }
+
+    static getLogger(loggerConf) { return new Logger(loggerConf); }
+    static getMetrics(metricsConf, logger) { return makeStatsD(metricsConf, logger); }
 }
 
 module.exports = ServiceRunner;


### PR DESCRIPTION
I'd like to make use of service-runner's metrics and logging libraries in subprocesses spawned from workers initiated by service-runner, and therefore need to expose configurations to them.

For example, see https://gerrit.wikimedia.org/r/#/c/355861/9/lib/config/ParsoidConfig.js

Any thoughts on an approach?

/cc @wikimedia/services @wikimedia/parsing 