### PR TITLE
Proper graceful shutdow

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -10,6 +10,7 @@ class HeapWatch {
         this.statsd = statsd;
         this.checkInterval = 60000; // Once per minute
         this.failCount = 0;
+        this.timeoutHandle = undefined;
     }
 
     watch() {
@@ -54,7 +55,14 @@ class HeapWatch {
         } else {
             this.failCount = 0;
         }
-        setTimeout(this.watch.bind(this), this.checkInterval);
+        this.timeoutHandle = setTimeout(this.watch.bind(this), this.checkInterval);
+    }
+
+    close() {
+        if (this.timeoutHandle) {
+            clearTimeout(this.timeoutHandle);
+            this.timeoutHandle = undefined;
+        }
     }
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -63,6 +63,11 @@ class Worker extends BaseService {
         if (this.interval) {
             clearInterval(this.interval);
         }
+        if (this._metrics) {
+            this._metrics.close();
+            this._metrics = undefined;
+        }
+        this._heapwatchHandle.close();
         if (Array.isArray(this.serviceReturns)) {
             return P.each(this.serviceReturns, (serviceRet) => {
                 if (serviceRet && typeof serviceRet.close === 'function') {
@@ -115,7 +120,8 @@ class Worker extends BaseService {
         // We try to restart workers before they get slow
         // Default to something close to the default node 2g limit
         const limitMB = parseInt(this.config.worker_heap_limit_mb, 10) || 1500;
-        new HeapWatch({ limitMB }, this._logger, this._metrics).watch();
+        this._heapwatchHandle = new HeapWatch({ limitMB }, this._logger, this._metrics);
+        this._heapwatchHandle.watch();
 
         if (cluster.isWorker) {
             this._workerHeartBeat();
@@ -159,16 +165,16 @@ class Worker extends BaseService {
             });
         })
         .then((res) => {
-            let ret;
+            let ret = res;
             this.serviceReturns = res;
-            // Make sure that only JSON-serializable values are returned.
-            try {
-                ret = JSON.parse(JSON.stringify(res));
-            } catch (e) {
-                ret = [e];
-            }
             // Signal that this worker finished startup
             if (cluster.isWorker) {
+                // Make sure that only JSON-serializable values are returned.
+                try {
+                    ret = JSON.parse(JSON.stringify(res));
+                } catch (e) {
+                    ret = [e];
+                }
                 process.send({ type: 'startup_finished', serviceReturns: ret });
             }
             return ret;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
mocha 4.0 would stop killing the process after running the tests, so we need to implement proper graceful server shutdown - so clean all the intervals/timeouts.

Also the test server will need access to the `Server` object, so when we're running in `num_workers === 0` mode we don't really send the serverRet object to another process, so we don't need to check if it's serializable.

cc @wikimedia/services 