### PR TITLE
Cascade close all child metrics reportes

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -234,7 +234,6 @@ class Logger {
      *
      * If the message should be logged, returns an object with bunyan log level
      * and a specialized logger for the given component, otherwise returns undefined
-
      * @param {string} levelPath a logging level + component ( e.g. 'warn/component_name' )
      * @return {Object|undefined} corresponding bunyan log level and a specialized logger
      * @private

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -91,7 +91,7 @@ function makeStatsD(options, logger) {
         return this.timing(names, Date.now() - startTime, samplingInterval);
     };
 
-    statsd.close = ((originalClose) => () => {
+    statsd.close = (originalClose => () => {
         if (typeof originalClose === 'function') {
             originalClose.apply(statsd);
             originalClose.apply(statsd);

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -94,7 +94,6 @@ function makeStatsD(options, logger) {
     statsd.close = (originalClose => () => {
         if (typeof originalClose === 'function') {
             originalClose.apply(statsd);
-            originalClose.apply(statsd);
         }
         statsd._children.forEach(child => child.close());
         statsd._children = [];

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -71,13 +71,16 @@ function makeStatsD(options, logger) {
         statsd = new StatsD(statsdOptions);
     }
 
+    statsd._children = [];
     // Support creating sub-metric clients with a fixed prefix. This is useful
     // for systematically categorizing metrics per-request, by using a
     // specific logger.
     statsd.makeChild = (name) => {
         const childOptions = Object.assign({}, options);
         childOptions._prefix = statsdOptions.prefix + normalizeName(name);
-        return makeStatsD(childOptions, logger);
+        const child = makeStatsD(childOptions, logger);
+        statsd._children.push(child);
+        return child;
     };
 
     // Add a static utility method for stat name normalization
@@ -87,6 +90,15 @@ function makeStatsD(options, logger) {
     statsd.endTiming = function endTiming(names, startTime, samplingInterval) {
         return this.timing(names, Date.now() - startTime, samplingInterval);
     };
+
+    statsd.close = ((originalClose) => () => {
+        if (typeof originalClose === 'function') {
+            originalClose.apply(statsd);
+            originalClose.apply(statsd);
+        }
+        statsd._children.forEach(child => child.close());
+        statsd._children = [];
+    })(statsd.close);
 
     return statsd;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
We need to cascade-close all the children of a certain metrics reported on exit

cc @wikimedia/services 