### PR TITLE
Report GC statistics to statsd; rel v2.4.3

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -221,7 +221,7 @@ function createDockerFile() {
         if (pkg.deploy.install_opts) {
             installOpts += `${pkg.deploy.install_opts.join(' ')} `;
         }
-        contents += `CMD ${beforeInstall}${npmCommand} install${installOpts}${afterInstall} && npm install heapdump `;
+        contents += `CMD ${beforeInstall}${npmCommand} install${installOpts}${afterInstall} && npm install heapdump gc-stats`;
         if (!opts.reshrinkwrap) {
             contents += '&& if ! [ -e npm-shrinkwrap.json ] ; then npm dedupe ; fi';
         }

--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const cluster = require('cluster');
+const gcStats = require('gc-stats')();
 
 class HeapWatch {
     constructor(conf, logger, statsd) {
@@ -13,7 +14,28 @@ class HeapWatch {
         this.timeoutHandle = undefined;
     }
 
+    _setGCMonitor() {
+        const gcTypeName = (typeID) => {
+            switch (typeID) {
+                case 1: return 'minor';
+                case 2: return 'major';
+                case 4: return 'incremental';
+                case 8: return 'weak';
+                case 15: return 'all';
+                default: return 'unknown';
+            }
+        };
+        gcStats.on('stats', (stats) => {
+            // Report memory stats to statsd. Use 'timing' (which isn't really
+            // timing-specific at all) instead of 'gauge' to get percentiles &
+            // min/max.
+            this.statsd.timing(`gc.${gcTypeName(stats.gctype)}`, stats.pause);
+        });
+    }
+
     watch() {
+        this._setGCMonitor();
+
         const usage = process.memoryUsage();
 
         // Report memory stats to statsd. Use 'timing' (which isn't really

--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const cluster = require('cluster');
-const gcStats = require('gc-stats')();
 
 class HeapWatch {
     constructor(conf, logger, statsd) {
@@ -15,22 +14,28 @@ class HeapWatch {
     }
 
     _setGCMonitor() {
-        const gcTypeName = (typeID) => {
-            switch (typeID) {
-                case 1: return 'minor';
-                case 2: return 'major';
-                case 4: return 'incremental';
-                case 8: return 'weak';
-                case 15: return 'all';
-                default: return 'unknown';
-            }
-        };
-        gcStats.on('stats', (stats) => {
-            // Report memory stats to statsd. Use 'timing' (which isn't really
-            // timing-specific at all) instead of 'gauge' to get percentiles &
-            // min/max.
-            this.statsd.timing(`gc.${gcTypeName(stats.gctype)}`, stats.pause);
-        });
+        try {
+            const gcStats = require('gc-stats')();
+            const gcTypeName = (typeID) => {
+                switch (typeID) {
+                    case 1: return 'minor';
+                    case 2: return 'major';
+                    case 4: return 'incremental';
+                    case 8: return 'weak';
+                    case 15: return 'all';
+                    default: return 'unknown';
+                }
+            };
+            gcStats.on('stats', (stats) => {
+                // Report memory stats to statsd. Use 'timing' (which isn't really
+                // timing-specific at all) instead of 'gauge' to get percentiles &
+                // min/max.
+                this.statsd.timing(`gc.${gcTypeName(stats.gctype)}`, stats.pause);
+            });
+        } catch (e) {
+            // gc-stats is a binary dependency, so if it's not installed
+            // ignore reporting GC metrics
+        }
     }
 
     watch() {

--- a/lib/master.js
+++ b/lib/master.js
@@ -230,25 +230,27 @@ class Master extends BaseService {
                 worker.on('exit', startupWorkerExit);
                 worker.on('message', (msg) => {
                     switch (msg.type) {
-                    case 'startup_finished':
-                        worker.removeListener('exit', startupWorkerExit);
-                        worker.on('exit', () => { workerExit(worker); });
-                        this._firstWorkerStarted = true;
-                        res.push(msg.serviceReturns);
-                        resolve(this._startWorkers(--remainingWorkers, res));
-                        break;
-                    case 'heartbeat':
-                        this._saveBeat(worker);
-                        break;
-                    case 'service_status':
-                        this._onStatusReceived(worker, msg.status);
-                        break;
-                    case 'ratelimiter_counters':
-                        return this._ratelimiter
-                            && this._ratelimiter.updateCounters(msg.value);
-                    default:
-                        this._logger.log('error/service-runner/master',
-                            `unknown message type received from worker ${msg.type}`);
+                        case 'startup_finished':
+                            worker.removeListener('exit', startupWorkerExit);
+                            worker.on('exit', () => {
+                                workerExit(worker);
+                            });
+                            this._firstWorkerStarted = true;
+                            res.push(msg.serviceReturns);
+                            resolve(this._startWorkers(--remainingWorkers, res));
+                            break;
+                        case 'heartbeat':
+                            this._saveBeat(worker);
+                            break;
+                        case 'service_status':
+                            this._onStatusReceived(worker, msg.status);
+                            break;
+                        case 'ratelimiter_counters':
+                            return this._ratelimiter
+                                && this._ratelimiter.updateCounters(msg.value);
+                        default:
+                            this._logger.log('error/service-runner/master',
+                                `unknown message type received from worker ${msg.type}`);
                     }
                 });
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -41,7 +41,8 @@
     "limitation": "^0.2.0",
     "semver": "^5.3.0",
     "yargs": "^7.1.0",
-    "dnscache": "^1.0.1"
+    "dnscache": "^1.0.1",
+    "gc-stats": "^1.0.2"
   },
   "devDependencies": {
     "eslint-config-node-services": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "limitation": "^0.2.0",
     "semver": "^5.3.0",
     "yargs": "^7.1.0",
-    "dnscache": "^1.0.1",
-    "gc-stats": "^1.0.2"
+    "dnscache": "^1.0.1"
   },
   "devDependencies": {
     "eslint-config-node-services": "^2.1.1",


### PR DESCRIPTION
It would be interesting to monitor not only service heap, but service GC pauses as well. Right now we're experiencing some perf issues regarding change-prop, but this metric could be interesting generically for all services.

However, this brings in a binary dependency to service-runner. We install `heapdump` by default anyway, so I guess it's not a big deal, but we only actually install `heapdump` in a docker file for production. Maybe better to have the same approach for the gc metrics reporter as well? Bikeshed opportunity.

cc @wikimedia/services 