### PR TITLE
Make GC metrics reported each second

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -2,6 +2,14 @@
 
 const cluster = require('cluster');
 
+const ZERO_CUMULATIVE_GC_INTERVAL = {
+    minor: 0,
+    major: 0,
+    incremental: 0,
+    weak: 0
+};
+const GC_REPORT_INTERVAL = 1000;
+
 class HeapWatch {
     constructor(conf, logger, statsd) {
         this.conf = conf =  conf || {};
@@ -11,6 +19,8 @@ class HeapWatch {
         this.checkInterval = 60000; // Once per minute
         this.failCount = 0;
         this.timeoutHandle = undefined;
+        this.gcReportInterval = undefined;
+        this.cumulativeGCTimes = ZERO_CUMULATIVE_GC_INTERVAL;
     }
 
     _setGCMonitor() {
@@ -30,7 +40,19 @@ class HeapWatch {
                 // Report memory stats to statsd. Use 'timing' (which isn't really
                 // timing-specific at all) instead of 'gauge' to get percentiles &
                 // min/max.
-                this.statsd.timing(`gc.${gcTypeName(stats.gctype)}`, stats.pause);
+                const type = gcTypeName(stats.gctype);
+                if (type !== 'unknown') {
+                    this.cumulativeGCTimes[gcTypeName(stats.gctype)] += stats.pause;
+                }
+                this.gcReportInterval = setInterval(() => {
+                    Object.keys(this.cumulativeGCTimes).forEach((gcType) => {
+                       const totalGCTime = this.cumulativeGCTimes[gcType];
+                       if (totalGCTime > 0) {
+                           this.statsd.timing(`gc.${gcType}`, totalGCTime);
+                       }
+                    });
+                    this.cumulativeGCTimes = ZERO_CUMULATIVE_GC_INTERVAL;
+                }, GC_REPORT_INTERVAL);
             });
         } catch (e) {
             // gc-stats is a binary dependency, so if it's not installed
@@ -89,6 +111,10 @@ class HeapWatch {
         if (this.timeoutHandle) {
             clearTimeout(this.timeoutHandle);
             this.timeoutHandle = undefined;
+        }
+        if (this.gcReportInterval) {
+            clearInterval(this.gcReportInterval);
+            this.gcReportInterval = undefined;
         }
     }
 }

--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -44,16 +44,16 @@ class HeapWatch {
                 if (type !== 'unknown') {
                     this.cumulativeGCTimes[gcTypeName(stats.gctype)] += stats.pause;
                 }
-                this.gcReportInterval = setInterval(() => {
-                    Object.keys(this.cumulativeGCTimes).forEach((gcType) => {
-                       const totalGCTime = this.cumulativeGCTimes[gcType];
-                       if (totalGCTime > 0) {
-                           this.statsd.timing(`gc.${gcType}`, totalGCTime);
-                       }
-                    });
-                    this.cumulativeGCTimes = ZERO_CUMULATIVE_GC_INTERVAL;
-                }, GC_REPORT_INTERVAL);
             });
+            this.gcReportInterval = setInterval(() => {
+                Object.keys(this.cumulativeGCTimes).forEach((gcType) => {
+                    const totalGCTime = this.cumulativeGCTimes[gcType];
+                    if (totalGCTime > 0) {
+                        this.statsd.timing(`gc.${gcType}`, totalGCTime);
+                    }
+                });
+                this.cumulativeGCTimes = ZERO_CUMULATIVE_GC_INTERVAL;
+            }, GC_REPORT_INTERVAL);
         } catch (e) {
             // gc-stats is a binary dependency, so if it's not installed
             // ignore reporting GC metrics

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The longer the workers live the more often they begin doing GC which floods metrics. Make the GC metrics go with a steady flow.

cc @wikimedia/services 