### PR TITLE
Use Object.assign to clone the constant zeros

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -20,7 +20,7 @@ class HeapWatch {
         this.failCount = 0;
         this.timeoutHandle = undefined;
         this.gcReportInterval = undefined;
-        this.cumulativeGCTimes = ZERO_CUMULATIVE_GC_INTERVAL;
+        this.cumulativeGCTimes = Object.assign({}, ZERO_CUMULATIVE_GC_INTERVAL);
     }
 
     _setGCMonitor() {
@@ -52,7 +52,7 @@ class HeapWatch {
                         this.statsd.timing(`gc.${gcType}`, totalGCTime);
                     }
                 });
-                this.cumulativeGCTimes = ZERO_CUMULATIVE_GC_INTERVAL;
+                this.cumulativeGCTimes = Object.assign({}, ZERO_CUMULATIVE_GC_INTERVAL);
             }, GC_REPORT_INTERVAL);
         } catch (e) {
             // gc-stats is a binary dependency, so if it's not installed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Obvious bug - we were changing the const object that was supposed to be unchanged.

cc @wikimedia/services 