### PR TITLE
GC: Send the stats only once they have been cleared; rel v2.4.6

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -46,13 +46,15 @@ class HeapWatch {
                 }
             });
             this.gcReportInterval = setInterval(() => {
+                const timings = {};
                 Object.keys(this.cumulativeGCTimes).forEach((gcType) => {
                     const totalGCTime = this.cumulativeGCTimes[gcType];
                     if (totalGCTime > 0) {
-                        this.statsd.timing(`gc.${gcType}`, totalGCTime);
+                        timings[`gc.${gcType}`] = totalGCTime;
                     }
                 });
                 this.cumulativeGCTimes = Object.assign({}, ZERO_CUMULATIVE_GC_INTERVAL);
+                Object.keys(timings).forEach(stat => this.statsd.timing(stat, timings[stat]));
             }, GC_REPORT_INTERVAL);
         } catch (e) {
             // gc-stats is a binary dependency, so if it's not installed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Sending stats requires network I/O, which means that the GC `stats` event could fire while we are sending them, which pollutes the statistics. In order to fix that, first only collect the stats to send, then clear them and finally send them.