### PR TITLE
Docker: Allow explicit base image names in pkg.deploy.target

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -110,9 +110,7 @@ function promisedSpawn(args, options) {
  */
 function createDockerFile() {
 
-    const baseImg =  targets[pkg.deploy.target]; // set the deploy target
-    const extraPkgs = ['nodejs', 'nodejs-legacy', 'npm', 'git', 'wget'];
-    let contents = `FROM ${baseImg}\n`;
+    const extraPkgs = ['nodejs', 'nodejs-legacy', 'git', 'wget', 'build-essential'];
     // An array where we store custom-sourced extra packages
     // Each element has 'repo_url', 'release', 'pool' and 'packages' properties
     // 'packages' is an array of package names
@@ -134,6 +132,15 @@ function createDockerFile() {
     if (!pkg.deploy.dependencies._all) {
         pkg.deploy.dependencies._all = [];
     }
+    if (!pkg.deploy.node) {
+        pkg.deploy.node = 'system';
+    }
+
+    const nodeVersion = pkg.deploy.node;
+    // set the deploy target
+    // allow the user to specify the exact target to use, like "debian:sid"
+    const baseImg = /^.+:.+$/.test(pkg.deploy.target) ? pkg.deploy.target : targets[pkg.deploy.target];
+    let contents = `FROM ${baseImg}\n`;
 
     if (!baseImg || baseImg === '') {
         console.error('ERROR: You must specify a valid target!');
@@ -141,6 +148,9 @@ function createDockerFile() {
         process.exit(2);
     }
 
+    if (nodeVersion === 'system') {
+        extraPkgs.push('npm');
+    }
     // get any additional packages that need to be installed
     Object.keys(pkg.deploy.dependencies).forEach((sys) => {
         if (sys === '_all' || (sys === baseImg || (new RegExp(sys)).test(baseImg))) {
@@ -168,22 +178,21 @@ function createDockerFile() {
         extraPkgs.push('apt-transport-https');
     }
 
-    contents += `RUN apt-get update && apt-get install -y ${extraPkgs.join(' ')} && rm -rf /var/lib/apt/lists/*\n`;
+    contents += `RUN apt-get update && apt-get install -y ${extraPkgs.join(' ')} && rm -rf /var/lib/apt/lists/*\n`; /**/
 
     if (customSourcePkgs.length) {
         contents += `RUN echo > /etc/apt/sources.list && ${customSourcePkgs.map(customSourcePkgSpec =>
             `echo deb "${customSourcePkgSpec.repo_url} ${customSourcePkgSpec.release} ${customSourcePkgSpec.pool}" >> /etc/apt/sources.list`).join(' && ')}\n`;
-        contents += `RUN apt-get update && ${customSourcePkgs.map(customSourcePkgSpec => `apt-get install -y --force-yes -t ${customSourcePkgSpec.release} ${customSourcePkgSpec.packages.join(' ')}`).join(' && ')} && rm -rf /var/lib/apt/lists/*\n`;
+        contents += `RUN apt-get update && ${customSourcePkgs.map(customSourcePkgSpec => `apt-get install -y --force-yes -t ${customSourcePkgSpec.release} ${customSourcePkgSpec.packages.join(' ')}`).join(' && ')} && rm -rf /var/lib/apt/lists/*\n`; /**/
     }
 
     if (debPkgs.length) {
         contents += `RUN ${debPkgs.map(uri => `wget ${uri} -O package.deb && dpkg -i package.deb && rm package.deb`).join(' && ')}\n`;
     }
 
-    const nodeVersion = pkg.deploy.node;
     let npmCommand = 'npm';
-    if (nodeVersion && nodeVersion !== 'system') {
-        const nvmDownloadURI = 'https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh';
+    if (nodeVersion !== 'system') {
+        const nvmDownloadURI = 'https://raw.githubusercontent.com/creationix/nvm/v0.33.6/install.sh';
         contents += 'ENV NVM_DIR /usr/local/nvm\n';
         contents += `RUN wget -qO- ${nvmDownloadURI} | bash && . $NVM_DIR/nvm.sh && nvm install ${nodeVersion}\n`;
         npmCommand = `. $NVM_DIR/nvm.sh && nvm use ${nodeVersion} && npm`;
@@ -469,9 +478,10 @@ function updateDeploy() {
             }
             return promisedSpawn(findAttr, { capture: true, ignoreErr: true });
         }).then(() => // add the built submodules
-        promisedGit(['add', 'node_modules']));
+            promisedGit(['add', 'node_modules']));
     }).then(() => // commit the changes
-        promisedGit(['commit', '-m', opts.commit_msg])).then(() => {
+        promisedGit(['commit', '-m', opts.commit_msg]))
+        .then(() => {
             if (!opts.review) {
                 console.log('\n\nChanges are sitting in the sync-repo branch in');
                 console.log(`${opts.dir} with the commit:`);

--- a/package.json
+++ b/package.json
@@ -44,12 +44,13 @@
     "dnscache": "^1.0.1"
   },
   "devDependencies": {
-    "eslint-config-node-services": "^2.1.1",
-    "eslint-config-wikimedia": "^0.4.0",
+    "eslint": "^4.12.0",
+    "eslint-config-node-services": "^2.2.5",
+    "eslint-config-wikimedia": "^0.5.0",
     "eslint-plugin-json": "^1.2.0",
     "eslint-plugin-jsdoc": "^3.0.2",
-    "mocha": "^3.2.0",
-    "mocha-eslint": "^3.0.1",
+    "mocha": "^4.0.1",
+    "mocha-eslint": "^4.1.0",
     "mocha-jshint": "^2.3.1",
     "bunyan-prettystream": "git+https://github.com/hadfieldn/node-bunyan-prettystream#master"
   }


### PR DESCRIPTION
So far, the exact target system was looked for through a combination of the target specified in the deploy section and the list of available targets. However, that can get tricky if the service doesn't have the `targets.yaml` file and when there are multiple versions of the same distribution. Hence, allow the user to specify the exact target to use. It is recognised by looking for `:` in the target name. This commit also fixes a bug whereby the target image was being deduced before the defaults were set.

Additionally, do not install `npm` by default, but rather `build-essential`. The latter is always needed, whereas the former is needed only in cases where the system nodejs package is used. Also, update `nvm` to v0.33.6.

Finally, update the linting dependencies and fix some linting errors.