### PR TITLE
Fix: Always install npm; release v2.4.8

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -110,7 +110,7 @@ function promisedSpawn(args, options) {
  */
 function createDockerFile() {
 
-    const extraPkgs = ['nodejs', 'nodejs-legacy', 'git', 'wget', 'build-essential'];
+    const extraPkgs = ['nodejs', 'nodejs-legacy', 'git', 'wget', 'build-essential', 'npm'];
     // An array where we store custom-sourced extra packages
     // Each element has 'repo_url', 'release', 'pool' and 'packages' properties
     // 'packages' is an array of package names
@@ -148,9 +148,6 @@ function createDockerFile() {
         process.exit(2);
     }
 
-    if (nodeVersion === 'system') {
-        extraPkgs.push('npm');
-    }
     // get any additional packages that need to be installed
     Object.keys(pkg.deploy.dependencies).forEach((sys) => {
         if (sys === '_all' || (sys === baseImg || (new RegExp(sys)).test(baseImg))) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.7",
+  "version": "2.4.8",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The `npm` system package depends on various other nodejs-related packages that are sometimes needed to build binary dependencies, so make sure that it is installed regardless of the actual npm version used.