### PR TITLE
Allow using custom NPM version in the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Options:
                                              [string] [default: "./config.yaml"]
   -f, --force        force the operation to execute   [boolean] [default: false]
   -d, --deploy-repo  build only the deploy repo       [boolean] [default: false]
-  -s, --reshrinkwrap re-generate shrinkwrap.json      [boolean] [default: false]
   -r, --review       send the patch to Gerrit after building the repo
                                                       [boolean] [default: false]
   --verbose          be verbose                       [boolean] [default: false]

--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -150,12 +150,6 @@ class BaseService {
                 describe: 'build only the deploy repo',
                 type: 'boolean'
             },
-            s: {
-                alias: 'reshrinkwrap',
-                default: false,
-                describe: 'rebuild shrinkwrap.json by removing and regenerating after npm install',
-                type: 'boolean'
-            },
             r: {
                 alias: 'review',
                 default: false,
@@ -206,7 +200,6 @@ class BaseService {
             displayVersion: args.v,
             build: args.build,
             buildDeploy: args.deployRepo,
-            reshrinkwrap: args.reshrinkwrap,
             sendReview: args.review,
             dockerStart: args.dockerStart || args.running,
             dockerTest: args.dockerTest || args.testing,

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -137,6 +137,7 @@ function createDockerFile() {
     }
 
     const nodeVersion = pkg.deploy.node;
+    const npmVersion = pkg.deploy.npm;
     // set the deploy target
     // allow the user to specify the exact target to use, like "debian:sid"
     const baseImg = /^.+:.+$/.test(pkg.deploy.target) ? pkg.deploy.target : targets[pkg.deploy.target];
@@ -219,18 +220,16 @@ function createDockerFile() {
     if (opts.deploy) {
         let beforeInstall = '';
         let afterInstall = '';
-        if (opts.reshrinkwrap) {
-            beforeInstall = 'rm -f npm-shrinkwrap.json && ';
-            afterInstall = '&& npm shrinkwrap ';
+        if (npmVersion) {
+            beforeInstall += `${npmCommand} install npm@${npmVersion} &&`;
+            npmCommand = './node_modules/.bin/npm';
+            afterInstall = '&& rm -rf ./node_modules/npm ./node_modules/.bin/npm'
         }
         let installOpts = ' --production ';
         if (pkg.deploy.install_opts) {
             installOpts += `${pkg.deploy.install_opts.join(' ')} `;
         }
-        contents += `CMD ${beforeInstall}${npmCommand} install${installOpts}${afterInstall} && npm install heapdump gc-stats`;
-        if (!opts.reshrinkwrap) {
-            contents += '&& if ! [ -e npm-shrinkwrap.json ] ; then npm dedupe ; fi';
-        }
+        contents += `CMD ${beforeInstall} ${npmCommand} install${installOpts} && ${npmCommand} install heapdump gc-stats ${afterInstall}`;
     } else if (opts.tests) {
         contents += `CMD ${npmCommand} test`;
     } else if (opts.coverage) {
@@ -559,7 +558,6 @@ function main(options, configuration) {
         verbose: options.verbose,
         need_build: options.buildDeploy && options.force,
         review: options.sendReview,
-        reshrinkwrap: options.reshrinkwrap,
         generate: options.generate,
         path: options.basePath
     };

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -223,7 +223,7 @@ function createDockerFile() {
         if (npmVersion) {
             beforeInstall += `${npmCommand} install npm@${npmVersion} &&`;
             npmCommand = './node_modules/.bin/npm';
-            afterInstall = '&& rm -rf ./node_modules/npm ./node_modules/.bin/npm'
+            afterInstall = '&& rm -rf ./node_modules/npm ./node_modules/.bin/npm';
         }
         let installOpts = ' --production ';
         if (pkg.deploy.install_opts) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.8",
+  "version": "2.4.9",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.4.9",
+  "version": "2.5.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Sometimes npm shipped with node has bugs that break the build
for certain packages. To be able to quickly workaround such bugs
we allow to select a custom npm version that should be used.

Also, the reshrinkwrap setting was never used since it's creation
and is not really needed in the future with introduction of
packages-lock.json file in npm v4, so it was removed.

cc @wikimedia/services 