### PR TITLE
Do not exit right away if there was a log message before.

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -370,6 +370,19 @@ class BaseService {
             }
         }
     }
+
+    /**
+     * Exits the process with a provided exit code with a little delay
+     * to allow asynchronous logging to complete.
+     * @param {?Number} [returnCode=0] exit code
+     * @protected
+     */
+    _exitProcess(returnCode) {
+        if (returnCode === undefined) {
+            returnCode = 0;
+        }
+        return P.delay(1000).then(() => process.exit(returnCode));
+    }
 }
 
 module.exports = BaseService;

--- a/lib/master.js
+++ b/lib/master.js
@@ -73,7 +73,7 @@ class Master extends BaseService {
             this.stop()
             .then(() => {
                 this._logger.log('info/service-runner/master', 'Exiting master');
-                process.exit(0);
+                return this._exitProcess(0);
             });
         };
 
@@ -183,11 +183,7 @@ class Master extends BaseService {
                             // Give up.
                             this._logger.log('fatal/service-runner/master',
                                 'startup failed, exiting master');
-                            // Don't exit right away, allow logger to process message
-                            setTimeout(() => {
-                                process.exit(1);
-                            }, 1000);
-                            return;
+                            return this._exitProcess(1);
                         }
                     }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -84,7 +84,7 @@ class Worker extends BaseService {
         process.on('SIGTERM', () => this.stop()
         .then(() => {
             this._logger.log('info/service-runner/worker', `Worker ${process.pid} shutting down`);
-            process.exit(0);
+            this._exitProcess(0);
         }));
 
         // Enable heap dumps in /tmp on kill -USR2.
@@ -182,13 +182,7 @@ class Worker extends BaseService {
         })
         .catch((e) => {
             this._logger.log('fatal/service-runner/worker', e);
-            // Give the logger some time to do its work before exiting
-            // synchronously.
-            // XXX: Consider returning a Promise from logger.log.
-            return P.delay(1000)
-            .then(() => {
-                process.exit(1);
-            });
+            return this._exitProcess(1);
         });
     }
 


### PR DESCRIPTION
Logging is async, so we need to allow some delay before calling
process.exit in order to let the logger process the message.

Follow-up for #177 

cc @wikimedia/services @arlolra 