### PR TITLE
Normalize the logging messages for easier filtering in kibana

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -98,7 +98,7 @@ class Master extends BaseService {
         return this._ratelimiter.setup()
         .then(() => this._startWorkers(this.config.num_workers))
         .tap(() => {
-            this._logger.log('warn/service-runner', 'Startup finished');
+            this._logger.log('warn/service-runner', 'startup finished');
             this._checkHeartbeat();
         });
     }
@@ -175,26 +175,28 @@ class Master extends BaseService {
                         return;
                     }
 
-                    if (!this._firstWorkerStarted) {
-                        this._logger.log('error/service-runner/master',
-                            `First worker died on startup with exit code ${code}`);
-                        if (this._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
-                            // We tried to start the first worker 3 times, but never succeed.
-                            // Give up.
-                            this._logger.log('fatal/service-runner/master',
-                                'startup failed, exiting master');
-                            return this._exitProcess(1);
-                        }
+                    if (!this._firstWorkerStarted
+                            && this._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
+                        // We tried to start the first worker 3 times, but never succeed.
+                        // Give up.
+                        this._logger.log('fatal/service-runner/master',
+                            'startup failed, exiting master');
+                        return this._exitProcess(1);
                     }
 
                     if (this._firstWorkerStarted) {
-                        this._logger.log('warn/service-runner/master',
-                            `worker ${worker.process.pid} died during startup (${code}),`
-                                + 'continue startup');
+                        this._logger.log('warn/service-runner/master', {
+                            message: 'worker died during startup, continue startup',
+                            exit_code: code,
+                            worker_pid: worker.process.pid
+                        });
                     } else {
-                        this._logger.log('warn/service-runner/master',
-                            `worker ${worker.process.pid} died during startup (${code}),`
-                                + ` continue startup attempt ${this._firstWorkerStartupAttempts}`);
+                        this._logger.log('warn/service-runner/master', {
+                            message: 'first worker died during startup, continue startup',
+                            worker_pid: worker.process.pid,
+                            exit_code: code,
+                            startup_attempt: this._firstWorkerStartupAttempts
+                        });
                     }
 
                     // Let all the exit listeners fire before reassigning current worker ID
@@ -208,9 +210,10 @@ class Master extends BaseService {
                         return;
                     }
 
-                    const exitCode = worker.process.exitCode;
                     const info = {
-                        message: `worker ${worker.process.pid} died (${exitCode}), restarting.`
+                        message: `worker died, restarting`,
+                        worker_pid: worker.process.pid,
+                        exit_code: worker.process.exitCode
                     };
                     if (this.workerStatusMap[worker.process.pid]
                         && this.workerStatusMap[worker.process.pid].status) {
@@ -269,9 +272,10 @@ class Master extends BaseService {
                     const lastBeat = this.workerStatusMap[worker.process.pid];
                     if (!lastBeat || (!lastBeat.killed && now - lastBeat.time
                             > this.config.worker_heartbeat_timeout)) {
-                        const info = {};
-                        info.message =
-                            `worker ${worker.process.pid} stopped sending heartbeats, killing.`;
+                        const info = {
+                            message: 'worker stopped sending heartbeats, killing.',
+                            worker_pid: worker.process.pid
+                        };
                         if (lastBeat && lastBeat.status) {
                             info.status = lastBeat.status;
                         }

--- a/lib/master.js
+++ b/lib/master.js
@@ -179,8 +179,11 @@ class Master extends BaseService {
                             && this._firstWorkerStartupAttempts++ >= STARTUP_ATTEMPTS_LIMIT) {
                         // We tried to start the first worker 3 times, but never succeed.
                         // Give up.
-                        this._logger.log('fatal/service-runner/master',
-                            'startup failed, exiting master');
+                        this._logger.log('fatal/service-runner/master', {
+                            message: 'startup failed, exiting master',
+                            worker_pid: worker.propcess.pid,
+                            exit_code: code
+                        });
                         return this._exitProcess(1);
                     }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -49,7 +49,7 @@ class Worker extends BaseService {
                         });
                     } catch (e) {
                         this._logger.log('warn/service-runner/worker/', {
-                            msg: 'Error sending worker status update',
+                            msg: 'error sending worker status update',
                             err: e
                         });
                     }
@@ -83,7 +83,10 @@ class Worker extends BaseService {
         // Worker.
         process.on('SIGTERM', () => this.stop()
         .then(() => {
-            this._logger.log('info/service-runner/worker', `Worker ${process.pid} shutting down`);
+            this._logger.log('info/service-runner/worker', {
+                message: 'worker shutting down',
+                worker_pid: process.pid
+            });
             this._exitProcess(0);
         }));
 
@@ -100,15 +103,17 @@ class Worker extends BaseService {
                 heapdump.writeSnapshot();
                 process.chdir(cwd);
             } catch (e) {
-                this._logger.log('warn/service-runner/worker',
-                    `Worker ${process.pid} received SIGUSR2, but heapdump is not installed`);
+                this._logger.log('warn/service-runner/worker', {
+                    message: 'worker received SIGUSR2, but heapdump is not installed',
+                    worker_pid: process.pid
+                });
             }
 
             // Also switch on trace logging for 5 seconds
-            console.error('Switching on trace logging for 5 seconds.');
+            console.error('switching on trace logging for 5 seconds.');
             this._logger.constructor.logTrace = true;
             setTimeout(() => {
-                console.error('Switching trace logging off.');
+                console.error('switching trace logging off.');
                 this._logger.constructor.logTrace = false;
             }, 5000);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The additional information has been moved to separate fields in logs,
like this we can easily filter out mesages about worker deaths and
filter a sequence of events that lead to the death of a particular
worker.

Bug: https://phabricator.wikimedia.org/T186761
cc @wikimedia/services @berndsi @mdholloway 