### PR TITLE
Don't install npm for build in case nvm will be used to install it.

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -110,7 +110,23 @@ function promisedSpawn(args, options) {
  */
 function createDockerFile() {
 
-    const extraPkgs = ['nodejs', 'nodejs-legacy', 'git', 'wget', 'build-essential', 'npm'];
+    const extraPkgs = [
+        'nodejs',
+        'nodejs-legacy',
+        'git',
+        'wget',
+        'build-essential',
+        // In case we'd need to fallback-to-build for some of the binary dependencies
+        // and use node-gyp, we'd need python, so let's install it just in case.
+        'python'
+    ];
+    const nodeVersion = pkg.deploy.node;
+
+    if (nodeVersion === 'system') {
+        // In case we're setting a specific node version we use nvm to install npm so we don't
+        // need to install npm through the apt-get
+        extraPkgs.push('npm');
+    }
     // An array where we store custom-sourced extra packages
     // Each element has 'repo_url', 'release', 'pool' and 'packages' properties
     // 'packages' is an array of package names
@@ -136,7 +152,6 @@ function createDockerFile() {
         pkg.deploy.node = 'system';
     }
 
-    const nodeVersion = pkg.deploy.node;
     const npmVersion = pkg.deploy.npm;
     // set the deploy target
     // allow the user to specify the exact target to use, like "debian:sid"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The npm package is not available in Debian Stretch, so the build
that's using it as a base image fails. However, we don't even use npm
installed from the apt repo as most of the time we use nvm to install.

See: https://github.com/nodejs/help/issues/1040
cc @wikimedia/services @niedzielski 