### PR TITLE
Fix Docker working directory permissions

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -219,7 +219,9 @@ function createDockerFile() {
             // In 'Docker for Mac' the mapping between users/groups
             // is done internally by docker, so we can run as root
             && os.type() !== 'Darwin') {
-        contents += `RUN groupadd -o -g ${opts.gid} -r rungroup && useradd -o -m -r -g rungroup -u ${opts.uid} runuser\nUSER runuser\nENV HOME=/home/runuser LINK=g++\n`;
+        contents += `RUN groupadd -o -g ${opts.gid} -r rungroup && useradd -o -m -r -g rungroup -u ${opts.uid} runuser\n`;
+        contents += 'RUN chown runuser:rungroup .\n';
+        contents += 'USER runuser\nENV HOME=/home/runuser LINK=g++\n';
     } else {
         contents += 'ENV HOME=/root/ LINK=g++\n';
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The current Dockerfile leaves root as the owner of the working directory,
which can cause permissions issues in the event that the run user created
on non-Mac platforms needs to modify files in the working directory.
Running docker-test for mobileapps on Linux currently fails for this
reason.  This patch adds a command to change ownership of the working
directory to runuser:rungroup.