### PR TITLE
Get rid of extend dependency and protect the log info object.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const extend = require('extend');
 const bunyan = require('bunyan');
 const gelfStream = require('gelf-stream');
 const syslogStream = require('bunyan-syslog-udp');
@@ -145,7 +144,7 @@ class Logger {
 
     _processConf(conf) {
         conf = conf || {};
-        conf = extend({}, conf);
+        conf = Object.assign({}, conf);
         conf.level = conf.level || DEF_LEVEL;
         let minLevelIdx = this._getLevelIndex(conf.level);
         if (Array.isArray(conf.streams)) {
@@ -271,7 +270,7 @@ class Logger {
     }
 
     child(args) {
-        const newArgs = extend({}, this.args, args);
+        const newArgs = Object.assign({}, this.args, args);
         return new Logger(this, newArgs);
     }
 
@@ -296,7 +295,7 @@ class Logger {
 
         if (typeof info === 'string') {
             const actualLogger = logger[level];
-            actualLogger.call(logger, extend({ levelPath }, this.args), info);
+            actualLogger.call(logger, Object.assign({ levelPath }, this.args), info);
         } else if (typeof info === 'object') {
             // Got an object.
             //
@@ -305,12 +304,12 @@ class Logger {
             // a msg, and pass that separately to bunyan.
             const msg = this._createMessage(info);
 
+            // Also pass in default parameters
+            info = Object.assign({}, info, this.args);
+
             // Inject the detailed levelpath.
             // 'level' is already used for the numeric level.
             info.levelPath = levelPath;
-
-            // Also pass in default parameters
-            info = extend(info, this.args);
             const actualLogger = logger[level];
             actualLogger.call(logger, info, msg);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "bluebird": "^3.5.0",
     "bunyan": "^1.8.10",
     "bunyan-syslog-udp": "^0.1.0",
-    "extend": "^3.0.0",
     "gelf-stream": "^1.1.1",
     "hot-shots": "^4.4.0",
     "js-yaml": "^3.8.3",

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,7 @@
 "use strict";
 
 require('mocha-jshint')();
-require('mocha-eslint')(['lib', 'service-runner.js']);
+require('mocha-eslint')(
+    ['lib', 'service-runner.js'],
+    { timeout: 5000 }
+);


### PR DESCRIPTION
When logging an error like `log('trace/error', err)`
we should not pass the actual instance of teh error object
into bunyan, because it assigns a bunch of properties to
the object the we do not want to publicly expose, like
_rootReq that has a `x-client-ip` header. Also it when
serializing it it apparently messes up with an original object,
so later on the original error gets wrapped into a 500.