### PR TITLE
Preserve the Error type when logging errors.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -307,7 +307,7 @@ class Logger {
 
             // Also pass in default parameters
             if (info instanceof Error) {
-                // We want to preserve Error type so that standard banyan serializers kick in.
+                // We want to preserve the Error type before bunyan serialisation kicks in.
                 info = Object.assign(copyError(info), this.args);
             } else {
                 info = Object.assign({}, info, this.args);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,6 +3,7 @@
 const bunyan = require('bunyan');
 const gelfStream = require('gelf-stream');
 const syslogStream = require('bunyan-syslog-udp');
+const copyError = require('utils-copy-error');
 
 const DEF_LEVEL = 'warn';
 const LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
@@ -305,7 +306,12 @@ class Logger {
             const msg = this._createMessage(info);
 
             // Also pass in default parameters
-            info = Object.assign({}, info, this.args);
+            if (info instanceof Error) {
+                // We want to preserve Error type so that standard banyan serializers kick in.
+                info = Object.assign(copyError(info), this.args);
+            } else {
+                info = Object.assign({}, info, this.args);
+            }
 
             // Inject the detailed levelpath.
             // 'level' is already used for the numeric level.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -40,7 +40,8 @@
     "limitation": "^0.2.0",
     "semver": "^5.3.0",
     "yargs": "^7.1.0",
-    "dnscache": "^1.0.1"
+    "dnscache": "^1.0.1",
+    "utils-copy-error": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^4.12.0",


### PR DESCRIPTION
We need to clone the info object when logging if it
is an Error since bynuan modifies the original object,
and that error is then reused to report the error to
the client. But we need to preserve the Error type so
that proper bynuan serializers kick in.

Bug: https://phabricator.wikimedia.org/T196124

cc @wikimedia/services @berndsi @mdholloway 