### PR TITLE
More generically copy the errors

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,7 +3,6 @@
 const bunyan = require('bunyan');
 const gelfStream = require('gelf-stream');
 const syslogStream = require('bunyan-syslog-udp');
-const copyError = require('utils-copy-error');
 
 const DEF_LEVEL = 'warn';
 const LEVELS = ['trace', 'debug', 'info', 'warn', 'error', 'fatal'];
@@ -307,8 +306,14 @@ class Logger {
 
             // Also pass in default parameters
             if (info instanceof Error) {
+                const copy = (err) => {
+                    const res = Object.assign(Object.create(Object.getPrototypeOf(err)), err);
+                    res.stack = err.stack;
+                    return res;
+                };
+
                 // We want to preserve the Error type before bunyan serialisation kicks in.
-                info = Object.assign(copyError(info), this.args);
+                info = Object.assign(copy(info), this.args);
             } else {
                 info = Object.assign({}, info, this.args);
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -40,8 +40,7 @@
     "limitation": "^0.2.0",
     "semver": "^5.3.0",
     "yargs": "^7.1.0",
-    "dnscache": "^1.0.1",
-    "utils-copy-error": "^1.0.1"
+    "dnscache": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^4.12.0",


### PR DESCRIPTION
The library used for copying before was not suited for our usage of the `HTTPError`, so just use the object.assign and clone the prototype.

cc @wikimedia/services 