### PR TITLE
Do not instantiate rate limiter if it's not required

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -93,9 +93,12 @@ class Master extends BaseService {
             .then(this._rollingRestart.bind(this));
         });
 
-        this._ratelimiter = new RateLimiterMaster(this.config.ratelimiter);
-
-        return this._ratelimiter.setup()
+        let ratelimiterSetup = P.resolve();
+        if (this.config.ratelimiter) {
+            this._ratelimiter = new RateLimiterMaster(this.config.ratelimiter);
+            ratelimiterSetup = this._ratelimiter.setup();
+        }
+        return ratelimiterSetup
         .then(() => this._startWorkers(this.config.num_workers))
         .tap(() => {
             this._logger.log('warn/service-runner', 'startup finished');

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,6 +62,7 @@ class Worker extends BaseService {
         super.stop();
         if (this.interval) {
             clearInterval(this.interval);
+            this.interval = undefined;
         }
         if (this._metrics) {
             this._metrics.close();
@@ -134,11 +135,13 @@ class Worker extends BaseService {
         }
 
         // Rate limiting.
-        if (cluster.isWorker) {
-            this._ratelimiter = new RateLimiterWorker(this.config.ratelimiter);
-        } else {
-            this._ratelimiter = new RateLimiterNoCluster(this.config.ratelimiter);
-            this._ratelimiter.setup();
+        if (this.config.ratelimiter) {
+            if (cluster.isWorker) {
+                this._ratelimiter = new RateLimiterWorker(this.config.ratelimiter);
+            } else {
+                this._ratelimiter = new RateLimiterNoCluster(this.config.ratelimiter);
+                this._ratelimiter.setup();
+            }
         }
 
         // Require service modules and start them

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.3",
+  "version": "2.6.4",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
In master-worker configuration the rate limiter sends quite a few messages back and forth from master to worker processes. If the rate limiter is not needed and not configured - just don't create it.

cc @wikimedia/services 