### PR TITLE
Introduce optional promise cancellation feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ var startupPromise = runner.start({
    you must override the app base path with either:
      - `APP_BASE_PATH` environment variable
      - `app_base_path` config stanza.
+- If project requires cancellable promises (which is disabled by default) you must set the
+`APP_ENABLE_CANCELLABLE_PROMISES` environment variable.
 - Default top-level config format (**draft**):
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ var startupPromise = runner.start({
      - `APP_BASE_PATH` environment variable
      - `app_base_path` config stanza.
 - If project requires cancellable promises (which is disabled by default) you must set the
-`APP_ENABLE_CANCELLABLE_PROMISES` environment variable.
+`APP_ENABLE_CANCELLABLE_PROMISES` environment variable to non-empty value (like `1` or `true`). For more information about
+ cancellable promises please refer to [Bluebird documentation](http://bluebirdjs.com/docs/api/cancellation.html).
 - Default top-level config format (**draft**):
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ var startupPromise = runner.start({
    you must override the app base path with either:
      - `APP_BASE_PATH` environment variable
      - `app_base_path` config stanza.
-- If project requires cancellable promises (which is disabled by default) you must set the
-`APP_ENABLE_CANCELLABLE_PROMISES` environment variable to non-empty value (like `1` or `true`). For more information about
+- If the project requires cancellable promises (which are disabled by default) you must set the
+`APP_ENABLE_CANCELLABLE_PROMISES` environment variable to a non-empty and truth-y value (like `1` or `true`). For more information about
  cancellable promises please refer to [Bluebird documentation](http://bluebirdjs.com/docs/api/cancellation.html).
 - Default top-level config format (**draft**):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {

--- a/service-runner.js
+++ b/service-runner.js
@@ -63,8 +63,9 @@ class ServiceRunner {
 module.exports = ServiceRunner;
 
 if (module.parent === null) {
-    // Cancellable promises have to enabled before we start any promise. Because ServiceRunner
-    // heavily rely on promises this is the best place to leave the config like that
+    // Cancellable promises have to enabled before we instantiate any promises. Because
+    // ServiceRunner heavily relies on promises this is the best place to leave the config
+    // like that.
     if (process.env.APP_ENABLE_CANCELLABLE_PROMISES) {
         P.config({
             cancellable: true

--- a/service-runner.js
+++ b/service-runner.js
@@ -14,6 +14,7 @@ const Master = require('./lib/master');
 const Worker = require('./lib/worker');
 const Logger = require('./lib/logger');
 const makeStatsD = require('./lib/statsd');
+const P = require('bluebird');
 
 // Disable cluster RR balancing; direct socket sharing has better throughput /
 // lower overhead. Also bump up somaxconn with this command:
@@ -62,6 +63,13 @@ class ServiceRunner {
 module.exports = ServiceRunner;
 
 if (module.parent === null) {
+    // Cancellable promises have to enabled before we start any promise. Because ServiceRunner
+    // heavily rely on promises this is the best place to leave the config like that
+    if (process.env.APP_ENABLE_CANCELLABLE_PROMISES) {
+        P.config({
+            cancellable: true
+        });
+    }
     // Run as a script: Start up
     new ServiceRunner().start();
 }


### PR DESCRIPTION
Some projects require the Bluebird promise cancellation feature.
That feature has to be enabled before any promise is created.
Because ServiceRunner service relies havily on the promises, and
it runs promises before it starts executing any application code
the only place to put that config is the ServiceRunner itself.