### PR TITLE
Provide sencible defaults for options passed via code

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -96,11 +96,18 @@ class BaseService {
     }
 
     _getOptions(opts) {
-
+        // Not including docker defaults since it's
+        // not possible to run docker scripts from code
+        const optsDefaults = {
+                num_workers: -1,
+                configFile: './config.yaml',
+                displayVersion: false,
+                verbose: false
+            };
         if (opts) {
             // no need to parse command-line args,
             // opts are already here
-            return opts;
+            return Object.assign(optsDefaults, opts);
         }
 
         // check process arguments
@@ -109,28 +116,28 @@ class BaseService {
         .options({
             n: {
                 alias: 'num-workers',
-                default: -1,
+                default: optsDefaults.num_workers,
                 describe: 'number of workers to start',
                 nargs: 1,
                 global: true
             },
             c: {
                 alias: 'config',
-                default: './config.yaml',
+                default: optsDefaults.configFile,
                 describe: 'YAML-formatted configuration file',
                 type: 'string',
                 nargs: 1,
                 global: true
             },
             verbose: {
-                default: false,
+                default: optsDefaults.verbose,
                 describe: 'be verbose',
                 type: 'boolean',
                 global: true
             },
             v: {
                 alias: 'version',
-                default: false,
+                default: optsDefaults.displayVersion,
                 describe: 'print the service\'s version and exit',
                 type: 'boolean',
                 global: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.12",
+  "version": "2.6.13",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
When the options are passed into the service-runner constructor via code (in tests for example) we need to provide the same defaults as for command-line arguments to ensure all the rest of the code works.