### PR TITLE
Have gc-stats and heapdump as optionalDeps; release v2.6.17

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -244,7 +244,7 @@ function createDockerFile() {
         if (pkg.deploy.install_opts) {
             installOpts += `${pkg.deploy.install_opts.join(' ')} `;
         }
-        contents += `CMD ${beforeInstall} ${npmCommand} install${installOpts} && ${npmCommand} install heapdump gc-stats ${afterInstall}`;
+        contents += `CMD ${beforeInstall} ${npmCommand} install${installOpts} ${afterInstall}`;
     } else if (opts.tests) {
         contents += `CMD ${npmCommand} test`;
     } else if (opts.coverage) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.6.16",
+  "version": "2.6.17",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -42,6 +42,10 @@
     "semver": "^5.6.0",
     "yargs": "^12.0.2",
     "dnscache": "^1.0.1"
+  },
+  "optionalDependencies": {
+    "gc-stats": "^1.2.1",
+    "heapdump": "^0.3.12"
   },
   "devDependencies": {
     "eslint": "^5.14.0",


### PR DESCRIPTION
Having `gc-stats` and `heapdump` being added to the build process post-facto is problematic for services being deployed to Kubernetes, as they won't be using the build script that comes with `service-runner`. Therefore, make them optional dependencies. This will allow us to have them installed in production after `npm install`, all the while not breaking the installation process for systems that do not support these modules.

Bug: [T205911](https://phabricator.wikimedia.org/T205911)