### PR TITLE
Replace invalid IPs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,8 @@ ratelimit:
   # optional: Kademlia backend
   # type: kad
   # seeds:
-  #  - 123.456.789.233
-  #  - 456.789.90.2
+  #  - 192.0.2.10
+  #  - 192.0.2.20
 
 # DNS caching, switched on by default. To disable caching use:
 # dns_cache: false


### PR DESCRIPTION
Even if just a documentation example, using invalid IPs is not legitimate
especially given there are RFCs with example IPs for this: Switch to
192.0.2.0/24 (aka TEST-NET-1) per  RFC 5737