### PR TITLE
Do not try to set the stack trace of undefined objects; rel v2.7.1

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -47,9 +47,9 @@ class BaseService {
         };
 
         this._unhandledRejectionHandler = (err) => {
-            if (!this._inLogger) {
+            if (!this._inLogger && err) {
                 this._inLogger = true;
-                if (!err.stack) {
+                if (!err.stack && err instanceof Error) {
                     Error.captureStackTrace(err);
                 }
                 this._logger.log('fatal/service-runner/unhandled', err);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Sometimes we can get `undefined` as the error object to log. When that's the case, don't attempt to add the stack trace, nor log it (since bunyan doesn't log empty messages).