### PR TITLE
Refactor shutdown sequence; rel v2.7.3

### DIFF
--- a/lib/base_service.js
+++ b/lib/base_service.js
@@ -30,6 +30,8 @@ class BaseService {
 
         this.options = this._getOptions(options);
 
+        this._running = false;
+
         this._logger = null;
         this._metrics = null;
         this._ratelimiter = null;
@@ -59,6 +61,7 @@ class BaseService {
     }
 
     stop() {
+        this._running = false;
         if (this._ratelimiter) {
             this._ratelimiter.stop();
         }
@@ -99,6 +102,7 @@ class BaseService {
     }
 
     start(conf) {
+        this._running = true;
         return this._getConfigUpdateAction(conf)
         .then(() => {
             const config = this.config;
@@ -433,7 +437,7 @@ class BaseService {
         if (returnCode === undefined) {
             returnCode = 0;
         }
-        return P.delay(1000).then(() => process.exit(returnCode));
+        return P.delay(100).then(() => process.exit(returnCode));
     }
 }
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -154,7 +154,6 @@ class Master extends BaseService {
             }, 60000);
             worker.once('disconnect', () => {
                 clearTimeout(timeout);
-                worker.process.kill('SIGKILL');
                 delete this._workerStatusMap[worker.process.pid];
                 resolve();
             });

--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -98,7 +98,7 @@ function makeStatsD(options, logger) {
         const child = statsd.childClient();
         // We can't use the prefix in clientOptions,
         // because it will be prepended to existing prefix.
-        child.prefix = statsd.prefix + normalizeName(name) + '.';
+        child.prefix = `${statsd.prefix}${normalizeName(name)}.`;
 
         // Attach normalizeName to make the childClient instance backwards-compatible
         // with the previously used StatsD instance

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -23,7 +23,6 @@ class Worker extends BaseService {
     constructor() {
         super();
 
-        this._shutdownHandler = null;
         this._dumpHeapHandler = null;
         this._messageHandler = null;
         this._serviceStatusHandler = null;
@@ -69,6 +68,12 @@ class Worker extends BaseService {
 
     stop() {
         super.stop();
+
+        this._logger.log('info/service-runner/worker', {
+            message: 'worker shutting down',
+            worker_pid: process.pid
+        });
+
         if (this.interval) {
             clearInterval(this.interval);
             this.interval = undefined;
@@ -80,10 +85,6 @@ class Worker extends BaseService {
         this._heapwatchHandle.close();
 
         // Remove signal handlers
-        if (this._shutdownHandler) {
-            process.removeListener('SIGTERM', this._shutdownHandler);
-            this._shutdownHandler = null;
-        }
         if (this._dumpHeapHandler) {
             process.removeListener('SIGUSR2', this._dumpHeapHandler);
             this._dumpHeapHandler = null;
@@ -109,17 +110,11 @@ class Worker extends BaseService {
     }
 
     _start() {
-        // Worker.
-        process.on('SIGTERM', this._shutdownHandler = () =>
-            this.stop()
-            .then(() => {
-                this._logger.log('info/service-runner/worker', {
-                    message: 'worker shutting down',
-                    worker_pid: process.pid
-                });
-                this._exitProcess(0);
-            })
-        );
+        if (cluster.isWorker) {
+            cluster.worker.on('disconnect', () =>
+                this.stop()
+                .then(() => this._exitProcess(0)));
+        }
 
         // Enable heap dumps in /tmp on kill -USR2.
         // See https://github.com/bnoordhuis/node-heapdump/
@@ -228,9 +223,13 @@ class Worker extends BaseService {
     _workerHeartBeat() {
         // We send heart beat 3 times more frequently than check it
         // to avoid possibility of wrong restarts
-        process.send({ type: 'heartbeat' });
-        this.interval = setInterval(() => {
+        if (this._running) {
             process.send({ type: 'heartbeat' });
+        }
+        this.interval = setInterval(() => {
+            if (this._running) {
+                process.send({ type: 'heartbeat' });
+            }
         }, this.config.worker_heartbeat_timeout / 3);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {
@@ -42,8 +42,8 @@
     "hot-shots": "^6.3.0",
     "js-yaml": "^3.13.1",
     "limitation": "^0.2.1",
-    "semver": "^6.1.2",
-    "yargs": "^13.2.4"
+    "semver": "^6.3.0",
+    "yargs": "^13.3.0"
   },
   "optionalDependencies": {
     "gc-stats": "^1.4.0",
@@ -51,12 +51,12 @@
   },
   "devDependencies": {
     "bunyan-prettystream": "git+https://github.com/hadfieldn/node-bunyan-prettystream#master",
-    "coveralls": "^3.0.3",
+    "coveralls": "^3.0.5",
     "eslint": "^5.16.0",
-    "eslint-config-wikimedia": "^0.12.0",
+    "eslint-config-wikimedia": "^0.13.1",
     "eslint-plugin-json": "^1.4.0",
-    "eslint-plugin-jsdoc": "^7.0.2",
-    "mocha": "^6.1.4",
+    "eslint-plugin-jsdoc": "^15.8.0",
+    "mocha": "^6.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^14.1.1"
   }


### PR DESCRIPTION
1. Update dependencies.
2. Don't attempt to send heartbeats if we're shutting down.
3. Refactor shutdown sequence. Before we were killing the worker when master detected the worker was disconnected. That's actually no good, cause master can emit the `disconnect` event before the worker does, so this doesn't leave the worker required time to gracefully kill itself after all the cleanup is done. Now we only SIGKILL the worker if it's stuck in its shutdown sequence for some time, and normally relying on the worker to correctly kill itself.

Bug: https://phabricator.wikimedia.org/T158265