### PR TITLE
Make nodejs-legacy optional. 

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -112,7 +112,6 @@ function createDockerFile() {
 
     const extraPkgs = [
         'nodejs',
-        'nodejs-legacy',
         'git',
         'wget',
         'build-essential',


### PR DESCRIPTION
Build breaks for debian buster or newer when trying to fetch nodejs-legacy package.