### PR TITLE
Prefixing and Normalizing Prometheus metrics

### DIFF
--- a/doc/2.7-2.8_Migration_Guide.md
+++ b/doc/2.7-2.8_Migration_Guide.md
@@ -50,7 +50,7 @@ class ExampleService {
             type: 'Counter',
             name: 'demo.called',
             prometheus: {
-                name: 'example_service_demo_called_count',
+                name: 'demo_called_count',
                 help: 'demo hit count',
             }
         }).increment();
@@ -71,7 +71,7 @@ class ExampleService {
                 type: 'Counter',
                 name: 'demo.called',
                 prometheus: {
-                    name: 'example_service_demo_called_count',
+                    name: 'demo_called_count',
                     help: 'demo hit count',
                 },
                 labels: {

--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -56,7 +56,6 @@ class HeapWatch {
                             prometheus: {
                                 name: `nodejs_gc_${gcType}_duration_seconds`,
                                 help: 'garbage collection pause duration seconds',
-                                staticLabels: { service: this.metrics.getServiceName() },
                                 buckets: [5e-4, 1e-3, 5e-3, 10e-3, 15e-3, 30e-3, 50e-3]
                             }
                         }).observe(totalGCTime * 1e-9); // nanoseconds to seconds
@@ -77,8 +76,7 @@ class HeapWatch {
             name: 'heap.rss',
             prometheus: {
                 name: 'nodejs_process_heap_rss_bytes',
-                help: 'process heap usage',
-                staticLabels: { service: this.metrics.getServiceName() }
+                help: 'process heap usage'
             }
         }).set(usage.rss);
         this.metrics.makeMetric({
@@ -86,8 +84,7 @@ class HeapWatch {
             name: 'heap.used',
             prometheus: {
                 name: 'nodejs_process_heap_used_bytes',
-                help: 'process heap usage',
-                staticLabels: { service: this.metrics.getServiceName() }
+                help: 'process heap usage'
             }
         }).set(usage.heapUsed);
         this.metrics.makeMetric({
@@ -95,8 +92,7 @@ class HeapWatch {
             name: 'heap.total',
             prometheus: {
                 name: 'nodejs_process_heap_total_bytes',
-                help: 'process heap usage',
-                staticLabels: { service: this.metrics.getServiceName() }
+                help: 'process heap usage'
             }
         }).set(usage.heapTotal);
         if (usage.heapUsed > this.limit) {

--- a/lib/metrics/prometheus.js
+++ b/lib/metrics/prometheus.js
@@ -17,6 +17,9 @@ class PrometheusMetric {
                 });
             }
         }
+        options.prometheus.name = this._normalize(`${options.prefix}_${options.prometheus.name}`);
+        options.prometheus.labelNames = options.prometheus.labelNames || [];
+        options.prometheus.labelNames = options.prometheus.labelNames.map(this._normalize);
         this.metric = new this.client[options.type]({
             name: options.prometheus.name,
             help: options.prometheus.help,
@@ -34,23 +37,33 @@ class PrometheusMetric {
         }
     }
 
+    _normalize(str) {
+        return String(str).replace( /[^a-z0-9]/g, '_' ) // replace non-alphanumerics
+            .replace( /_+/g, '_' ) // dedupe underscores
+            .replace( /(^_+|_+$)/g, '' ); // trim leading and trailing underscores
+    }
+
     increment(amount, labels) {
         this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         this.metric.labels.apply(this.metric, labels).inc(amount);
     }
 
     decrement(amount, labels) {
         this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         this.metric.labels.apply(this.metric, labels).dec(amount);
     }
 
     observe(value, labels) {
         this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         this.metric.labels.apply(this.metric, labels).observe(value);
     }
 
     gauge(amount, labels) {
         this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         if (amount < 0) {
             this.metric.labels.apply(this.metric, labels).dec(Math.abs(amount));
         } else {
@@ -60,14 +73,19 @@ class PrometheusMetric {
 
     set(value, labels) {
         this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         this.metric.labels.apply(this.metric, labels).set(value);
     }
 
     timing(value, labels) {
+        this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         this.set(value, labels);
     }
 
     endTiming(startTime, labels) {
+        this._handleStaticLabels(labels);
+        labels.map(this._normalize);
         this.timing(Date.now() - startTime, labels);
     }
 }
@@ -77,9 +95,12 @@ class PrometheusClient {
         this.options = options;
         this.logger = logger;
         this.client = Prometheus;
+        // by default prefix with service name
+        this.prefix = options.prefix ? options.prefix : options.name;
     }
 
     makeMetric(options) {
+        options.prefix = this.prefix;
         return new PrometheusMetric(options, this.client);
     }
 

--- a/test/features/tests.js
+++ b/test/features/tests.js
@@ -124,7 +124,7 @@ describe('service-runner tests', () => {
         .then(() => {
             assert.strictEqual(response.status, 200, 'Must get 200 response');
             assert.ok(
-                response.body.indexOf('hitcount{worker_id="0"} 1') !== -1,
+                response.body.indexOf('service_runner_hitcount{worker_id="0"} 1') !== -1,
                 'Must register the hit in prometheus output.'
             );
         })
@@ -150,7 +150,7 @@ describe('service-runner tests', () => {
         .then(() => {
             assert.strictEqual(response.status, 200, 'Must get 200 response');
             assert.ok(
-                response.body.indexOf('hitcount{worker_id="1"} 1') !== -1,
+                response.body.indexOf('service_runner_hitcount{worker_id="1"} 1') !== -1,
                 'Must register the hit in prometheus output.'
             );
         })
@@ -176,7 +176,7 @@ describe('service-runner tests', () => {
         .then(() => {
             assert.strictEqual(response.status, 200, 'Must get 200 response');
             assert.ok(
-                response.body.indexOf('hitcount{worker_id="1"} 1') !== -1,
+                response.body.indexOf('service_runner_hitcount{worker_id="1"} 1') !== -1,
                 'Must register the hit in prometheus output.'
             );
         })


### PR DESCRIPTION
Add default prefix to Prometheus metrics.
Normalize Prometheus metric name and label keys and values.

Bug: T247820