### PR TITLE
Add support for having named logging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ logging:
   sampled_levels:
     'trace/webrequest': 0.2
   streams:
+  - type: stdout # log to stdout
+    named_levels: true # emit log level name instead of index. e.g. INFO vs 30
   # Use gelf-stream -> logstash
   - type: gelf
     host: logstash1003.eqiad.wmnet

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -12,6 +12,17 @@ function extractSimpleLevel(levelPath) {
     return typeof levelPath === 'string' && levelPath.split('/')[0];
 }
 
+function NamedLevelStdout() {
+    return {
+        write: (entry) => {
+            // Kind of inefficient approach
+            var logObject = JSON.parse(entry);
+            logObject.level = bunyan.nameFromLevel[logObject.level].toUpperCase();
+            process.stdout.write(JSON.stringify(logObject) + '\n');
+        }
+    };
+}
+
 const streamConverter = {
     gelf(stream, conf) {
         let host = stream.host;
@@ -43,6 +54,12 @@ const streamConverter = {
     stdout(stream, conf) {
         return {
             stream: process.stdout,
+            level: stream.level || conf.level
+        };
+    },
+    namedstdout(stream, conf) {
+        return {
+            stream: NamedLevelStdout(),
             level: stream.level || conf.level
         };
     },

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Writable = require('stream').Writable;
 const bunyan = require('bunyan');
 const gelfStream = require('gelf-stream');
 const syslogStream = require('bunyan-syslog-udp');
@@ -12,15 +13,23 @@ function extractSimpleLevel(levelPath) {
     return typeof levelPath === 'string' && levelPath.split('/')[0];
 }
 
-function NamedLevelStdout() {
-    return {
-        write: (entry) => {
-            // Kind of inefficient approach
-            var logObject = JSON.parse(entry);
-            logObject.level = bunyan.nameFromLevel[logObject.level].toUpperCase();
-            process.stdout.write(JSON.stringify(logObject) + '\n');
-        }
-    };
+class NamedLevelStdout extends Writable {
+    constructor(downstream, options = {}) {
+        super(Object.assign(options, { objectMode: true }));
+        this.downstream = downstream;
+    }
+    _write(logEntry, encoding, callback) {
+        logEntry.level = bunyan.nameFromLevel[logEntry.level].toUpperCase();
+        this.downstream.write(
+            JSON.stringify(logEntry) + '\n',
+            encoding,
+            callback
+        );
+    }
+    destroy() {
+        super.destroy();
+        this.downstream.destroy();
+    }
 }
 
 const streamConverter = {
@@ -52,16 +61,18 @@ const streamConverter = {
         };
     },
     stdout(stream, conf) {
-        return {
-            stream: process.stdout,
-            level: stream.level || conf.level
-        };
-    },
-    namedstdout(stream, conf) {
-        return {
-            stream: NamedLevelStdout(),
-            level: stream.level || conf.level
-        };
+        if ( stream.named_levels ) {
+            return {
+                type: 'raw',
+                stream: new NamedLevelStdout(process.stdout),
+                level: stream.level || conf.level
+            };
+        } else {
+            return {
+                stream: process.stdout,
+                level: stream.level || conf.level
+            };
+        }
     },
     debug(stream, conf) {
         try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.7.6",
+  "version": "2.7.7",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
Why:
service-runner, when logging to stdout delegates to bunyan stdout
logging process that ends up creating log entries with level specified
as an integer, even though the code everywhere might be using named
levels. This hasn't been a problem up to now because we sparringly
relied on that, but with the move to service-runner apps on kubernetes
and the logging pipeline this is starting to cause issues, namely
https://phabricator.wikimedia.org/T239459. It would be nice if
service-runner allowed to log to stdout named loglevels

What:
Add a simple, albeit probably inefficient function due to all the JSON
encoding/decoding that wraps process.stdout and changes the level
attribute from an integer to a string. Provide it as an additional
stream.

The output looks like this:

{"name":"myapp","hostname":"buster","pid":5835,"level":"INFO","msg":"This is logging","time":"2020-04-08T09:03:09.294Z","v":0}

instead of:

{"name":"myapp","hostname":"buster","pid":5835,"level":30,"msg":"This is logging","time":"2020-04-08T09:03:09.294Z","v":0}

Bump service-runner version to reflect the change

Bug: T239459