### PR TITLE
Bugfix: clone labels when interpolating metric name

### DIFF
--- a/lib/metrics/utils/index.js
+++ b/lib/metrics/utils/index.js
@@ -28,15 +28,16 @@ function zipLabels(options, labels) {
 
 // Formats label set with metric name
 function formatLabels(options, labels) {
+    let formattedLabels = [...labels];
     if (options.labels.names) {
-        labels = zipLabels(options, labels);
+        formattedLabels = zipLabels(options, formattedLabels);
     }
     if (options.labels.labelPosition === 'before') {
-        labels.push(options.name);
+        formattedLabels.push(options.name);
     } else {
-        labels.unshift(options.name);
+        formattedLabels.unshift(options.name);
     }
-    return labels;
+    return formattedLabels;
 }
 
 module.exports.normalizeName = normalizeName;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
When the log metrics output is first in line,
`metrics.utils.formatLabels` will mutate the labels array.
This mutation will leak to the other metrics clients and manifest
as an Invalid number of arguments in prom-client.

Bug: T278141