### PR TITLE
Don't normalize prometheus label values

### DIFF
--- a/lib/metrics/prometheus.js
+++ b/lib/metrics/prometheus.js
@@ -11,19 +11,16 @@ class PrometheusMetric {
         if (this.options.labels === undefined) {
             this.options.labels = { names: [] };
         }
-        this.staticLabels = this.options.prometheus.staticLabels;
-        if (this.staticLabels !== undefined) {
-            if (Object.keys(this.staticLabels).length > 0) {
-                Object.keys(this.staticLabels).forEach((name) => {
-                    this.options.labels.names.unshift(name);
-                    this.staticLabels[name] = this._normalize(this.staticLabels[name]);
-                });
-            }
-        }
+        this.staticLabels = this.options.prometheus.staticLabels || {};
+
+        // Add staticLabel names to list of known label names.
+        Object.keys(this.staticLabels).forEach((labelName) => {
+            this.options.labels.names.unshift(labelName);
+        });
+        // Normalize all the label names.
+        this.options.labels.names = this.options.labels.names.map(this._normalize)
+
         this.options.prometheus.name = this._normalize(this.options.prometheus.name);
-        this.options.prometheus.labelNames = this.options.prometheus.labelNames || [];
-        this.options.prometheus.labelNames = this.options.prometheus.labelNames
-            .map(this._normalize);
         this.metric = new this.client[this.options.type]({
             name: this.options.prometheus.name,
             help: this.options.prometheus.help,
@@ -33,61 +30,75 @@ class PrometheusMetric {
         });
     }
 
-    _handleStaticLabels(labels) {
-        const updatedLabels = [...labels];
-        if (this.staticLabels !== undefined) {
-            Object.keys(this.staticLabels).forEach((name) => {
-                if (updatedLabels.indexOf(this.staticLabels[name]) === -1) {
-                    updatedLabels.unshift(this.staticLabels[name]);
-                }
-            });
-        }
-        return updatedLabels;
-    }
-
+    /**
+     * Normalizes a prometheus string. Should be used for label
+     * and metric names, but is not needed for label values.
+     *
+     * @param {string} str
+     * @return {string}
+     */
     _normalize(str) {
         return String(str).replace( /\W/g, '_' ) // replace non-alphanumerics
             .replace( /_+/g, '_' ) // dedupe underscores
             .replace( /(^_+|_+$)/g, '' ); // trim leading and trailing underscores
     }
 
-    increment(amount, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
-        this.metric.labels.apply(this.metric, updatedLabels).inc(amount);
+    /**
+     * Gets label values array for this metric
+     * including both static and dynamic labels merged together.
+     *
+     * @param {Array} labelValues
+     * @return {Array}
+     */
+     _getLabelValues(labelValues) {
+        // make a clone of labelValues.
+        const updatedLabelValues = [...labelValues];
+        // Add staticLabel values to updatedLabelValues if they aren't already listed.
+        Object.keys(this.staticLabels).forEach((labelName) => {
+            if (updatedLabelValues.indexOf(this.staticLabels[labelName]) === -1) {
+                updatedLabelValues.unshift(this.staticLabels[labelName]);
+            }
+        });
+        return updatedLabelValues;
     }
 
-    decrement(amount, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
-        this.metric.labels.apply(this.metric, updatedLabels).dec(amount);
+    increment(amount, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
+        this.metric.labels.apply(this.metric, updatedLabelValues).inc(amount);
     }
 
-    observe(value, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
-        this.metric.labels.apply(this.metric, updatedLabels).observe(value);
+    decrement(amount, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
+        this.metric.labels.apply(this.metric, updatedLabelValues).dec(amount);
     }
 
-    gauge(amount, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
+    observe(value, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
+        this.metric.labels.apply(this.metric, updatedLabelValues).observe(value);
+    }
+
+    gauge(amount, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
         if (amount < 0) {
-            this.metric.labels.apply(this.metric, updatedLabels).dec(Math.abs(amount));
+            this.metric.labels.apply(this.metric, updatedLabelValues).dec(Math.abs(amount));
         } else {
-            this.metric.labels.apply(this.metric, updatedLabels).inc(amount);
+            this.metric.labels.apply(this.metric, updatedLabelValues).inc(amount);
         }
     }
 
-    set(value, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
-        this.metric.labels.apply(this.metric, updatedLabels).set(value);
+    set(value, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
+        this.metric.labels.apply(this.metric, updatedLabelValues).set(value);
     }
 
-    timing(value, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
-        this.observe(value, updatedLabels);
+    timing(value, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
+        this.observe(value, updatedLabelValues);
     }
 
-    endTiming(startTime, labels) {
-        const updatedLabels = this._handleStaticLabels(labels).map(this._normalize);
-        this.timing(Date.now() - startTime, updatedLabels);
+    endTiming(startTime, labelValues) {
+        const updatedLabelValues = this._getLabelValues(labelValues);
+        this.timing(Date.now() - startTime, updatedLabelValues);
     }
 }
 


### PR DESCRIPTION
Slight refactor of prometheus label names initialization.  Should
be a no-op that just makes the code a bit more readable.