### PR TITLE
Remove GC stats feature

### DIFF
--- a/lib/heapwatch.js
+++ b/lib/heapwatch.js
@@ -2,14 +2,6 @@
 
 const cluster = require('cluster');
 
-const ZERO_CUMULATIVE_GC_INTERVAL = {
-    minor: 0,
-    major: 0,
-    incremental: 0,
-    weak: 0
-};
-const GC_REPORT_INTERVAL = 1000;
-
 class HeapWatch {
     constructor(conf, logger, metrics) {
         this.conf = conf = conf || {};
@@ -19,55 +11,6 @@ class HeapWatch {
         this.checkInterval = 60000; // Once per minute
         this.failCount = 0;
         this.timeoutHandle = undefined;
-        this.gcReportInterval = undefined;
-        this.cumulativeGCTimes = Object.assign({}, ZERO_CUMULATIVE_GC_INTERVAL);
-        this.reportStatsHandler = (stats) => {
-                // Report GC timings to statsd (in nanoseconds).
-                const type = this._gcTypeName(stats.gctype);
-                if (type !== 'unknown') {
-                    this.cumulativeGCTimes[this._gcTypeName(stats.gctype)] += stats.pause;
-                }
-        };
-        this._gcStats = null;
-    }
-
-    _gcTypeName(typeID) {
-        switch (typeID) {
-            case 1: return 'minor';
-            case 2: return 'major';
-            case 4: return 'incremental';
-            case 8: return 'weak';
-            case 15: return 'all';
-            default: return 'unknown';
-        }
-    }
-
-    setGCMonitor() {
-        try {
-            this._gcStats = require('gc-stats')();
-            this._gcStats.on('stats', this.reportStatsHandler);
-            this.gcReportInterval = setInterval(() => {
-                Object.keys(this.cumulativeGCTimes).forEach((gcType) => {
-                    const totalGCTime = this.cumulativeGCTimes[gcType];
-                    if (totalGCTime > 0) {
-                        this.metrics.makeMetric({
-                            type: 'Histogram',
-                            name: `gc.${gcType}`,
-                            prometheus: {
-                                name: `nodejs_gc_${gcType}_duration_seconds`,
-                                help: 'garbage collection pause duration seconds',
-                                staticLabels: this.metrics.getServiceLabel(),
-                                buckets: [5e-4, 1e-3, 5e-3, 10e-3, 15e-3, 30e-3, 50e-3]
-                            }
-                        }).observe(totalGCTime * 1e-9); // nanoseconds to seconds
-                    }
-                });
-                this.cumulativeGCTimes = Object.assign({}, ZERO_CUMULATIVE_GC_INTERVAL);
-            }, GC_REPORT_INTERVAL);
-        } catch (e) {
-            // gc-stats is a binary dependency, so if it's not installed
-            // ignore reporting GC metrics
-        }
     }
 
     watch() {
@@ -134,16 +77,9 @@ class HeapWatch {
     }
 
     close() {
-        if (this._gcStats) {
-            this._gcStats.removeListener('stats', this.reportStatsHandler);
-        }
         if (this.timeoutHandle) {
             clearTimeout(this.timeoutHandle);
             this.timeoutHandle = undefined;
-        }
-        if (this.gcReportInterval) {
-            clearInterval(this.gcReportInterval);
-            this.gcReportInterval = undefined;
         }
     }
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -149,7 +149,6 @@ class Worker extends BaseService {
         const limitMB = parseInt(this.config.worker_heap_limit_mb, 10) || 1500;
         this._heapwatchHandle = new HeapWatch({ limitMB }, this._logger, this._metrics);
         this._heapwatchHandle.watch();
-        this._heapwatchHandle.setGCMonitor();
 
         if (cluster.isWorker) {
             this._setupWorkerHeartBeat();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-runner",
-  "version": "2.8.4",
+  "version": "2.9.0",
   "description": "Generic nodejs service supervisor / cluster runner",
   "main": "service-runner.js",
   "bin": {


### PR DESCRIPTION
The feature emits metrics about garbage collection.
To my knowledge these metrics have never benefitted
anyone in 5 years of their existance. Now gc-stats
package used to collect the metric has issues, so
let's just remove the feature entirely.