### PR TITLE
Upgrade prom-client from ^11.5.3 to ^12.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"js-yaml": "^3.13.1",
 				"limitation": "^0.2.3",
 				"lodash.clonedeep": "^4.5.0",
-				"prom-client": "^11.5.3",
+				"prom-client": "^12.0.0",
 				"semver": "^7.6.0",
 				"tar": "^6.2.0",
 				"yargs": "^17.7.2"
@@ -4452,14 +4452,14 @@
 			}
 		},
 		"node_modules/prom-client": {
-			"version": "11.5.3",
-			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-			"integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+			"integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
 			"dependencies": {
 				"tdigest": "^0.1.1"
 			},
 			"engines": {
-				"node": ">=6.1"
+				"node": ">=10"
 			}
 		},
 		"node_modules/psl": {
@@ -8985,9 +8985,9 @@
 			}
 		},
 		"prom-client": {
-			"version": "11.5.3",
-			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
-			"integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/prom-client/-/prom-client-12.0.0.tgz",
+			"integrity": "sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==",
 			"requires": {
 				"tdigest": "^0.1.1"
 			}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"js-yaml": "^3.13.1",
 		"limitation": "^0.2.3",
 		"lodash.clonedeep": "^4.5.0",
-		"prom-client": "^11.5.3",
+		"prom-client": "^12.0.0",
 		"semver": "^7.6.0",
 		"tar": "^6.2.0",
 		"yargs": "^17.7.2"


### PR DESCRIPTION
12.0.0 provides GC metrics which are wanted for various uses.

The breaking changes are mostly the dropping of support for Node 6 and 8, which don't affect us, removal of deprecated constructor use, and change in how default metrics are now collected, which aren't currently used:

  https://github.com/siimon/prom-client/releases/tag/v12.0.0

https://phabricator.wikimedia.org/T350180