### PR TITLE
Require node 18 or higher, update to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "service-runner",
-	"version": "5.0.0",
+	"version": "6.0.0",
 	"description": "Generic nodejs service supervisor / cluster runner",
 	"main": "service-runner.js",
 	"bin": {
@@ -31,7 +31,7 @@
 	},
 	"homepage": "https://github.com/wikimedia/service-runner",
 	"engines": {
-		"node": ">=16"
+		"node": ">=18"
 	},
 	"dependencies": {
 		"bluebird": "^3.7.2",


### PR DESCRIPTION
Due to localhost now pointing to IPv6 instead of IPv4 as of node 18, TestServer now explicitly serves 127.0.0.1 instead of localhost. 

Consumers who import the TestServer from service runner will need to update their test runner applications to serve from 127.0.0.1 as well in order to upgrade from node16 to node 18, in addition to upgrading from 5.0.0 to 6.0.0.